### PR TITLE
added databasus as it will replace postgresus

### DIFF
--- a/SERVICES.md
+++ b/SERVICES.md
@@ -80,6 +80,7 @@
 ## D
 - [dashdot](https://github.com/MauriceNino/dashdot) ([yml](https://github.com/traefikturkey/onramp/tree/master/services-available/dashdot.yml)): Dashboard for monitoring docker containers
 - [dashy](https://github.com/Lissy93/dashy) ([yml](https://github.com/traefikturkey/onramp/tree/master/services-available/dashy.yml)): Customizable dashboard for displaying information
+- [databasus](https://github.com/databasus/databasus)([yml](https://github.com/traefikturkey/onramp/tree/master/services-available/databasus.yml)): Databasus is a free, open source and self-hosted tool to backup databases. Make backups with different storages (S3, Google Drive, FTP, etc.) and notifications about progress (Slack, Discord, Telegram, etc.). Previously known as Postgresus
 - [dawarich](https://github.com/Freika/dawarich) ([yml](https://github.com/traefikturkey/onramp/tree/master/services-available/dawarich.yml)): Self-hostable alternative to Google Location History (Google Maps Timeline)
 - [dockerizalo](https://github.com/undernightcore/dockerizalo) ([yml](https://github.com/traefikturkey/onramp/tree/master/services-available/dockerizalo.yml)): Docker build and deployment platform 
 - [docker-mirror](https://hub.docker.com/_/registry) ([yml](https://github.com/traefikturkey/onramp/tree/master/services-available/docker-mirror.yml)): docker mirror / registry for caching docker images
@@ -246,7 +247,7 @@
 - [portainer](https://github.com/portainer/portainer) ([yml](https://github.com/traefikturkey/onramp/tree/master/services-available/portainer.yml)): Lightweight container management ui
 - [postfix](https://github.com/juanluisbaptiste/docker-postfix) ([yml](https://github.com/traefikturkey/onramp/tree/master/services-available/postfix.yml)): Mail transfer agent (mta) for sending and receiving emails
 - [postgres](https://hub.docker.com/_/postgres) ([yml](https://github.com/traefikturkey/onramp/tree/master/services-available/postgres.yml)): Powerful open-source relational database system
-- [postgresus](https://github.com/RostislavDugin/postgresus) ([yml](https://github.com/traefikturkey/onramp/tree/master/services-available/postgresus.yml)): Free, open-source and self-hosted solution for automated PostgreSQL backups
+- [postgresus](https://github.com/RostislavDugin/postgresus) ([yml](https://github.com/traefikturkey/onramp/tree/master/services-available/postgresus.yml)): Free, open-source and self-hosted solution for automated PostgreSQL backups(deprecation 12/2026)
 - [postman](https://hub.docker.com/r/kasmweb/postman) ([yml](https://github.com/traefikturkey/onramp/tree/master/services-available/postman.yml)): Collaboration platform for api development
 - [prestashop](https://hub.docker.com/r/prestashop/prestashop/) ([yml](https://github.com/traefikturkey/onramp/tree/master/services-available/prestashop.yml)): E-commerce platform
 - [prometheus-alertmanager](https://github.com/prometheus/alertmanager) ([yml](https://github.com/traefikturkey/onramp/tree/master/services-available/prometheus-alertmanager.yml)): Manages alerts from prometheus monitoring

--- a/services-available/databasus.yml
+++ b/services-available/databasus.yml
@@ -1,0 +1,28 @@
+networks:
+  traefik:
+    external: true
+
+# Databasus is a free, open source and self-hosted tool to backup databases. Make backups with different storages (S3, Google Drive, FTP, etc.) and notifications about progress (Slack, Discord, Telegram, etc.). Previously known as DATABASUS (see migration guide).
+# https://github.com/databasus/databasus
+
+services:
+  databasus:
+    image: databasus/databasus:${DATABASUS_DOCKER_TAG:-latest}
+    container_name: ${DATABASUS_CONTAINER_NAME:-databasus}
+    restart: ${DATABASUS_RESTART:-unless-stopped}
+    networks:
+      - traefik
+    environment:
+      - PUID=${PUID:-1000}
+      - PGID=${PGID:-1000}
+      - TZ=${TZ}
+    volumes:
+      - ./etc/databasus-data:/databasus-data
+    labels:
+      - joyride.host.name=${DATABASUS_CONTAINER_NAME:-DATABASUS}.${HOST_DOMAIN}
+      - traefik.enable=true
+      - traefik.http.routers.DATABASUS.entrypoints=websecure
+      - traefik.http.routers.DATABASUS.rule=Host(`${DATABASUS_CONTAINER_NAME:-DATABASUS}.${HOST_DOMAIN}`)
+      - traefik.http.services.DATABASUS.loadbalancer.server.port=4005
+      - com.centurylinklabs.watchtower.enable=${DATABASUS_WATCHTOWER_ENABLED:-true}
+      - autoheal=true


### PR DESCRIPTION
Postgresus has moved to Databasus as it now supports backing up MySQL, MariaDB, Postgres, and MongoDB. They provided a "migration guide" but you really have to just re-add all of your databases.