### PR TITLE
feat(joyride): add Traefik external hosts sync for DNS

### DIFF
--- a/make.d/traefik.mk
+++ b/make.d/traefik.mk
@@ -1,0 +1,14 @@
+#########################################################
+##
+## Traefik External DNS Sync
+##
+## Syncs Traefik external Host() rules to Joyride DNS.
+## Extracts hostnames from external-enabled/*.yml and
+## writes them to etc/joyride/hosts.d/hosts.
+##
+#########################################################
+
+traefik-sync-dns: sietch-build ## Sync Traefik external hosts to Joyride DNS
+	$(SIETCH_RUN) python /scripts/traefik_hosts.py sync
+
+.PHONY: traefik-sync-dns

--- a/sietch/scripts/traefik_hosts.py
+++ b/sietch/scripts/traefik_hosts.py
@@ -1,0 +1,354 @@
+#!/usr/bin/env python
+"""
+traefik_hosts.py - Extract Traefik external Host() rules for Joyride DNS
+
+Parses external-enabled/*.yml files, extracts Host() rules, resolves environment
+variables, and generates a hosts file for Joyride DNS ingestion.
+
+Commands:
+  sync    Parse externals and update Joyride hosts file
+
+Features:
+- Early exit if Joyride service is not enabled
+- Excludes middleware-only YAML files
+- Resolves {{env "VAR"}} Go template syntax
+- FQDN-based deduplication (new entries override existing)
+- Preserves existing host entries and comments
+"""
+
+import argparse
+import os
+import re
+import sys
+from pathlib import Path
+
+
+# Files that only define middlewares, not routers with Host() rules
+MIDDLEWARE_ONLY_FILES = frozenset({
+    "middleware.yml",
+    "authentik_middleware.yml",
+    "authelia_middlewares.yml",
+    "crowdsec-bouncer.yml",
+})
+
+# Regex to extract Host() rules from Traefik dynamic config
+# Matches: Host(`{{env "VAR"}}.{{env "HOST_DOMAIN"}}`) or Host(`hostname.domain`)
+HOST_RULE_PATTERN = re.compile(r'rule:\s*"Host\(`([^`]+)`\)"')
+
+# Regex to extract {{env "VAR"}} Go template syntax
+ENV_TEMPLATE_PATTERN = re.compile(r'\{\{env\s+"([^"]+)"\}\}')
+
+
+class TraefikHostsExtractor:
+    """Extract Host() rules from Traefik external configs for Joyride DNS."""
+
+    def __init__(
+        self,
+        base_dir: Path | None = None,
+        env_vars: dict[str, str] | None = None,
+    ):
+        """Initialize extractor.
+
+        Args:
+            base_dir: Repository root directory (default: /app for container context)
+            env_vars: Environment variables for template resolution (default: os.environ)
+        """
+        self.base_dir = base_dir or Path("/app")
+        self.env_vars = env_vars if env_vars is not None else dict(os.environ)
+
+        # Paths
+        self.services_enabled = self.base_dir / "services-enabled"
+        self.external_enabled = self.base_dir / "external-enabled"
+        self.hosts_file = self.base_dir / "etc" / "joyride" / "hosts.d" / "hosts"
+
+    def check_joyride_enabled(self) -> bool:
+        """Check if Joyride service is enabled.
+
+        Returns:
+            True if joyride.yml exists in services-enabled
+        """
+        joyride_yml = self.services_enabled / "joyride.yml"
+        return joyride_yml.exists()
+
+    def load_env_files(self) -> None:
+        """Load environment variables from .env and .env.external files."""
+        env_file = self.services_enabled / ".env"
+        env_external = self.services_enabled / ".env.external"
+
+        for env_path in [env_file, env_external]:
+            if env_path.exists():
+                self._parse_env_file(env_path)
+
+    def _parse_env_file(self, path: Path) -> None:
+        """Parse a .env file and add to env_vars.
+
+        Args:
+            path: Path to .env file
+        """
+        with open(path, encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                # Skip empty lines and comments
+                if not line or line.startswith("#"):
+                    continue
+                # Parse KEY=VALUE
+                if "=" in line:
+                    key, _, value = line.partition("=")
+                    key = key.strip()
+                    value = value.strip()
+                    # Remove quotes if present
+                    if value.startswith('"') and value.endswith('"'):
+                        value = value[1:-1]
+                    elif value.startswith("'") and value.endswith("'"):
+                        value = value[1:-1]
+                    # Don't override existing env vars (allows CLI override)
+                    if key not in self.env_vars:
+                        self.env_vars[key] = value
+
+    def resolve_template(self, template: str) -> str | None:
+        """Resolve {{env "VAR"}} templates in a string.
+
+        Args:
+            template: String containing {{env "VAR"}} patterns
+
+        Returns:
+            Resolved string, or None if any required variable is empty/missing
+        """
+        result = template
+
+        for match in ENV_TEMPLATE_PATTERN.finditer(template):
+            var_name = match.group(1)
+            var_value = self.env_vars.get(var_name, "")
+
+            if not var_value:
+                return None
+
+            result = result.replace(match.group(0), var_value)
+
+        return result
+
+    def extract_hosts_from_file(self, yaml_path: Path) -> list[tuple[str, str]]:
+        """Extract Host() rules from a Traefik external config file.
+
+        Args:
+            yaml_path: Path to YAML file
+
+        Returns:
+            List of (fqdn, source_file) tuples
+        """
+        hosts: list[tuple[str, str]] = []
+        source_name = yaml_path.stem  # e.g., "homeassistant" from "homeassistant.yml"
+
+        try:
+            content = yaml_path.read_text(encoding="utf-8")
+        except OSError as e:
+            print(f"Warning: Could not read {yaml_path}: {e}", file=sys.stderr)
+            return hosts
+
+        for match in HOST_RULE_PATTERN.finditer(content):
+            host_template = match.group(1)
+            resolved = self.resolve_template(host_template)
+
+            if resolved:
+                hosts.append((resolved, source_name))
+            else:
+                # Identify which variable is missing
+                missing_vars = []
+                for env_match in ENV_TEMPLATE_PATTERN.finditer(host_template):
+                    var_name = env_match.group(1)
+                    if not self.env_vars.get(var_name):
+                        missing_vars.append(var_name)
+
+                if missing_vars:
+                    print(
+                        f"Skipped {source_name}: {', '.join(missing_vars)} not set",
+                        file=sys.stderr,
+                    )
+
+        return hosts
+
+    def get_external_files(self) -> list[Path]:
+        """Get list of external config files to process.
+
+        Returns:
+            List of YAML file paths, excluding middleware-only files
+        """
+        if not self.external_enabled.exists():
+            return []
+
+        files = []
+        for path in self.external_enabled.glob("*.yml"):
+            if path.name not in MIDDLEWARE_ONLY_FILES:
+                files.append(path)
+
+        return sorted(files)
+
+    def read_existing_hosts(self) -> tuple[list[str], dict[str, str]]:
+        """Read existing hosts file content.
+
+        Returns:
+            Tuple of (comment_lines, fqdn_to_line_mapping)
+        """
+        comments: list[str] = []
+        entries: dict[str, str] = {}  # fqdn -> full line
+
+        if not self.hosts_file.exists():
+            return comments, entries
+
+        try:
+            content = self.hosts_file.read_text(encoding="utf-8")
+        except OSError:
+            return comments, entries
+
+        for line in content.splitlines():
+            stripped = line.strip()
+
+            if not stripped:
+                continue
+            elif stripped.startswith("#"):
+                comments.append(line)
+            else:
+                # Parse "IP FQDN [aliases...]" format
+                parts = stripped.split()
+                if len(parts) >= 2:
+                    fqdn = parts[1]
+                    entries[fqdn] = line
+
+        return comments, entries
+
+    def write_hosts_file(
+        self,
+        comments: list[str],
+        entries: dict[str, str],
+    ) -> int:
+        """Write hosts file with updated entries.
+
+        Args:
+            comments: Comment lines to preserve
+            entries: FQDN -> line mapping
+
+        Returns:
+            Number of entries written
+        """
+        # Ensure directory exists
+        self.hosts_file.parent.mkdir(parents=True, exist_ok=True)
+
+        lines = []
+
+        # Add preserved comments first
+        lines.extend(comments)
+
+        # Add blank line after comments if there are comments
+        if comments:
+            lines.append("")
+
+        # Add entries sorted by FQDN
+        for fqdn in sorted(entries.keys()):
+            lines.append(entries[fqdn])
+
+        # Write file
+        self.hosts_file.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+        return len(entries)
+
+    def sync(self) -> int:
+        """Main sync operation.
+
+        Returns:
+            Exit code (0 = success, 1 = error)
+        """
+        # Early exit if joyride not enabled
+        if not self.check_joyride_enabled():
+            print(
+                "Joyride service is not enabled. "
+                "Enable it with: make enable-service NAME=joyride",
+                file=sys.stderr,
+            )
+            return 1
+
+        # Load environment variables
+        self.load_env_files()
+
+        # Check required vars
+        hostip = self.env_vars.get("HOSTIP", "")
+        host_domain = self.env_vars.get("HOST_DOMAIN", "")
+
+        if not hostip:
+            print("Error: HOSTIP not set in environment", file=sys.stderr)
+            return 1
+
+        if not host_domain:
+            print("Error: HOST_DOMAIN not set in environment", file=sys.stderr)
+            return 1
+
+        # Get external files to process
+        external_files = self.get_external_files()
+
+        if not external_files:
+            print("No external configs found in external-enabled/")
+            return 0
+
+        # Read existing hosts file
+        comments, entries = self.read_existing_hosts()
+
+        # Extract hosts from each file
+        added: list[str] = []
+        updated: list[str] = []
+
+        for yaml_path in external_files:
+            hosts = self.extract_hosts_from_file(yaml_path)
+
+            for fqdn, source in hosts:
+                new_line = f"{hostip} {fqdn}"
+
+                if fqdn in entries:
+                    if entries[fqdn] != new_line:
+                        updated.append(fqdn)
+                else:
+                    added.append(fqdn)
+
+                entries[fqdn] = new_line
+
+        # Write updated hosts file
+        total = self.write_hosts_file(comments, entries)
+
+        # Print summary
+        if added:
+            print(f"Added: {', '.join(added)}")
+        if updated:
+            print(f"Updated: {', '.join(updated)}")
+
+        print(f"Wrote {total} host entries to {self.hosts_file}")
+
+        return 0
+
+
+def main() -> int:
+    """Command-line entry point."""
+    parser = argparse.ArgumentParser(
+        description="Extract Traefik external Host() rules for Joyride DNS",
+    )
+    parser.add_argument(
+        "command",
+        choices=["sync"],
+        help="Command to run",
+    )
+    parser.add_argument(
+        "--base-dir",
+        type=Path,
+        default=None,
+        help="Repository root directory (default: /app)",
+    )
+
+    args = parser.parse_args()
+
+    extractor = TraefikHostsExtractor(base_dir=args.base_dir)
+
+    if args.command == "sync":
+        return extractor.sync()
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/sietch/tests/test_traefik_hosts.py
+++ b/sietch/tests/test_traefik_hosts.py
@@ -1,0 +1,476 @@
+"""Tests for traefik_hosts.py - Traefik external Host() rule extraction."""
+
+import pytest
+import sys
+from pathlib import Path
+
+# Add scripts to path for imports
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+
+from traefik_hosts import TraefikHostsExtractor
+
+
+# Helper function to create Traefik YAML with proper formatting
+def traefik_yaml(router_name: str, host_var: str, domain_var: str = "HOST_DOMAIN") -> str:
+    """Generate Traefik YAML with Host() rule using Go template syntax."""
+    return (
+        f'http:\n'
+        f'  routers:\n'
+        f'    {router_name}:\n'
+        f'      rule: "Host(`{{{{env "{host_var}"}}}}.{{{{env "{domain_var}"}}}}`)"'
+    )
+
+
+class TestJoyrideEnabledCheck:
+    """Tests for joyride enabled check."""
+
+    def test_returns_false_when_joyride_not_enabled(self, tmp_path):
+        """Should return False when joyride.yml does not exist."""
+        services_enabled = tmp_path / "services-enabled"
+        services_enabled.mkdir()
+
+        extractor = TraefikHostsExtractor(base_dir=tmp_path)
+
+        assert extractor.check_joyride_enabled() is False
+
+    def test_returns_true_when_joyride_enabled(self, tmp_path):
+        """Should return True when joyride.yml exists."""
+        services_enabled = tmp_path / "services-enabled"
+        services_enabled.mkdir()
+        (services_enabled / "joyride.yml").write_text("# joyride config")
+
+        extractor = TraefikHostsExtractor(base_dir=tmp_path)
+
+        assert extractor.check_joyride_enabled() is True
+
+
+class TestEnvFileLoading:
+    """Tests for environment file loading."""
+
+    def test_loads_env_file(self, tmp_path):
+        """Should load variables from .env file."""
+        services_enabled = tmp_path / "services-enabled"
+        services_enabled.mkdir()
+        (services_enabled / ".env").write_text("HOST_DOMAIN=example.com\nHOSTIP=192.168.1.10\n")
+
+        extractor = TraefikHostsExtractor(base_dir=tmp_path, env_vars={})
+        extractor.load_env_files()
+
+        assert extractor.env_vars["HOST_DOMAIN"] == "example.com"
+        assert extractor.env_vars["HOSTIP"] == "192.168.1.10"
+
+    def test_loads_env_external_file(self, tmp_path):
+        """Should load variables from .env.external file."""
+        services_enabled = tmp_path / "services-enabled"
+        services_enabled.mkdir()
+        (services_enabled / ".env.external").write_text("HOMEASSISTANT_HOST_NAME=hass\n")
+
+        extractor = TraefikHostsExtractor(base_dir=tmp_path, env_vars={})
+        extractor.load_env_files()
+
+        assert extractor.env_vars["HOMEASSISTANT_HOST_NAME"] == "hass"
+
+    def test_skips_comments_and_empty_lines(self, tmp_path):
+        """Should skip comments and empty lines in env files."""
+        services_enabled = tmp_path / "services-enabled"
+        services_enabled.mkdir()
+        (services_enabled / ".env").write_text(
+            "# This is a comment\n"
+            "\n"
+            "VALID_VAR=value\n"
+            "# Another comment\n"
+        )
+
+        extractor = TraefikHostsExtractor(base_dir=tmp_path, env_vars={})
+        extractor.load_env_files()
+
+        assert extractor.env_vars.get("VALID_VAR") == "value"
+        assert "# This is a comment" not in extractor.env_vars
+
+    def test_removes_quotes_from_values(self, tmp_path):
+        """Should remove surrounding quotes from values."""
+        services_enabled = tmp_path / "services-enabled"
+        services_enabled.mkdir()
+        (services_enabled / ".env").write_text(
+            'DOUBLE_QUOTED="value1"\n'
+            "SINGLE_QUOTED='value2'\n"
+            "UNQUOTED=value3\n"
+        )
+
+        extractor = TraefikHostsExtractor(base_dir=tmp_path, env_vars={})
+        extractor.load_env_files()
+
+        assert extractor.env_vars["DOUBLE_QUOTED"] == "value1"
+        assert extractor.env_vars["SINGLE_QUOTED"] == "value2"
+        assert extractor.env_vars["UNQUOTED"] == "value3"
+
+    def test_does_not_override_existing_env_vars(self, tmp_path):
+        """Should not override existing env vars (allows CLI override)."""
+        services_enabled = tmp_path / "services-enabled"
+        services_enabled.mkdir()
+        (services_enabled / ".env").write_text("HOSTIP=192.168.1.10\n")
+
+        extractor = TraefikHostsExtractor(
+            base_dir=tmp_path,
+            env_vars={"HOSTIP": "10.0.0.1"},  # Pre-set
+        )
+        extractor.load_env_files()
+
+        assert extractor.env_vars["HOSTIP"] == "10.0.0.1"
+
+
+class TestTemplateResolution:
+    """Tests for {{env "VAR"}} template resolution."""
+
+    def test_resolves_single_variable(self):
+        """Should resolve a single {{env "VAR"}} template."""
+        extractor = TraefikHostsExtractor(
+            env_vars={"HOST_DOMAIN": "example.com"},
+        )
+
+        result = extractor.resolve_template('{{env "HOST_DOMAIN"}}')
+
+        assert result == "example.com"
+
+    def test_resolves_multiple_variables(self):
+        """Should resolve multiple {{env "VAR"}} templates."""
+        extractor = TraefikHostsExtractor(
+            env_vars={
+                "HOMEASSISTANT_HOST_NAME": "hass",
+                "HOST_DOMAIN": "example.com",
+            },
+        )
+
+        result = extractor.resolve_template(
+            '{{env "HOMEASSISTANT_HOST_NAME"}}.{{env "HOST_DOMAIN"}}'
+        )
+
+        assert result == "hass.example.com"
+
+    def test_returns_none_for_missing_variable(self):
+        """Should return None when variable is not set."""
+        extractor = TraefikHostsExtractor(env_vars={})
+
+        result = extractor.resolve_template('{{env "MISSING_VAR"}}')
+
+        assert result is None
+
+    def test_returns_none_for_empty_variable(self):
+        """Should return None when variable is empty."""
+        extractor = TraefikHostsExtractor(
+            env_vars={"EMPTY_VAR": ""},
+        )
+
+        result = extractor.resolve_template('{{env "EMPTY_VAR"}}')
+
+        assert result is None
+
+    def test_returns_none_if_any_variable_missing(self):
+        """Should return None if any variable in the template is missing."""
+        extractor = TraefikHostsExtractor(
+            env_vars={"HOST_DOMAIN": "example.com"},
+        )
+
+        result = extractor.resolve_template(
+            '{{env "MISSING_NAME"}}.{{env "HOST_DOMAIN"}}'
+        )
+
+        assert result is None
+
+
+class TestHostExtraction:
+    """Tests for Host() rule extraction from YAML files."""
+
+    def test_extracts_single_host(self, tmp_path):
+        """Should extract a single Host() rule."""
+        external_enabled = tmp_path / "external-enabled"
+        external_enabled.mkdir()
+        (external_enabled / "homeassistant.yml").write_text(
+            traefik_yaml("homeassistant", "HOMEASSISTANT_HOST_NAME")
+        )
+
+        extractor = TraefikHostsExtractor(
+            base_dir=tmp_path,
+            env_vars={
+                "HOMEASSISTANT_HOST_NAME": "hass",
+                "HOST_DOMAIN": "example.com",
+            },
+        )
+
+        hosts = extractor.extract_hosts_from_file(
+            external_enabled / "homeassistant.yml"
+        )
+
+        assert len(hosts) == 1
+        assert hosts[0] == ("hass.example.com", "homeassistant")
+
+    def test_extracts_multiple_hosts_from_file(self, tmp_path):
+        """Should extract multiple Host() rules from a single file."""
+        yaml_content = (
+            'http:\n'
+            '  routers:\n'
+            '    service1:\n'
+            '      rule: "Host(`{{env "SVC1_HOST_NAME"}}.{{env "HOST_DOMAIN"}}`)"'
+            '\n'
+            '    service2:\n'
+            '      rule: "Host(`{{env "SVC2_HOST_NAME"}}.{{env "HOST_DOMAIN"}}`)"'
+        )
+        external_enabled = tmp_path / "external-enabled"
+        external_enabled.mkdir()
+        (external_enabled / "multi.yml").write_text(yaml_content)
+
+        extractor = TraefikHostsExtractor(
+            base_dir=tmp_path,
+            env_vars={
+                "SVC1_HOST_NAME": "svc1",
+                "SVC2_HOST_NAME": "svc2",
+                "HOST_DOMAIN": "example.com",
+            },
+        )
+
+        hosts = extractor.extract_hosts_from_file(external_enabled / "multi.yml")
+
+        assert len(hosts) == 2
+        assert ("svc1.example.com", "multi") in hosts
+        assert ("svc2.example.com", "multi") in hosts
+
+    def test_skips_host_with_missing_variable(self, tmp_path, capsys):
+        """Should skip hosts where required variable is missing."""
+        external_enabled = tmp_path / "external-enabled"
+        external_enabled.mkdir()
+        (external_enabled / "service.yml").write_text(
+            traefik_yaml("service", "MISSING_HOST_NAME")
+        )
+
+        extractor = TraefikHostsExtractor(
+            base_dir=tmp_path,
+            env_vars={"HOST_DOMAIN": "example.com"},
+        )
+
+        hosts = extractor.extract_hosts_from_file(external_enabled / "service.yml")
+
+        assert len(hosts) == 0
+
+        # Check that warning was printed
+        captured = capsys.readouterr()
+        assert "Skipped service" in captured.err
+        assert "MISSING_HOST_NAME" in captured.err
+
+
+class TestMiddlewareExclusion:
+    """Tests for middleware-only file exclusion."""
+
+    def test_excludes_middleware_yml(self, tmp_path):
+        """Should exclude middleware.yml from file list."""
+        external_enabled = tmp_path / "external-enabled"
+        external_enabled.mkdir()
+        (external_enabled / "middleware.yml").write_text("# middlewares only")
+        (external_enabled / "homeassistant.yml").write_text("# has routers")
+
+        extractor = TraefikHostsExtractor(base_dir=tmp_path)
+        files = extractor.get_external_files()
+
+        filenames = [f.name for f in files]
+        assert "middleware.yml" not in filenames
+        assert "homeassistant.yml" in filenames
+
+    def test_excludes_all_middleware_only_files(self, tmp_path):
+        """Should exclude all middleware-only files."""
+        external_enabled = tmp_path / "external-enabled"
+        external_enabled.mkdir()
+
+        middleware_files = [
+            "middleware.yml",
+            "authentik_middleware.yml",
+            "authelia_middlewares.yml",
+            "crowdsec-bouncer.yml",
+        ]
+
+        for name in middleware_files:
+            (external_enabled / name).write_text("# middleware only")
+
+        (external_enabled / "valid.yml").write_text("# has routers")
+
+        extractor = TraefikHostsExtractor(base_dir=tmp_path)
+        files = extractor.get_external_files()
+
+        filenames = [f.name for f in files]
+        for name in middleware_files:
+            assert name not in filenames
+        assert "valid.yml" in filenames
+
+
+class TestHostsFileDeduplication:
+    """Tests for FQDN-based deduplication."""
+
+    def test_deduplicates_by_fqdn(self, tmp_path):
+        """Should deduplicate entries by FQDN, keeping latest."""
+        # Set up joyride as enabled
+        services_enabled = tmp_path / "services-enabled"
+        services_enabled.mkdir()
+        (services_enabled / "joyride.yml").write_text("# enabled")
+        (services_enabled / ".env").write_text("HOSTIP=192.168.1.10\nHOST_DOMAIN=example.com\n")
+        (services_enabled / ".env.external").write_text("SVC_HOST_NAME=svc\n")
+
+        # Create existing hosts file with old IP
+        hosts_dir = tmp_path / "etc" / "joyride" / "hosts.d"
+        hosts_dir.mkdir(parents=True)
+        (hosts_dir / "hosts").write_text("10.0.0.1 svc.example.com\n")
+
+        # Create external config
+        external_enabled = tmp_path / "external-enabled"
+        external_enabled.mkdir()
+        (external_enabled / "service.yml").write_text(
+            traefik_yaml("svc", "SVC_HOST_NAME")
+        )
+
+        extractor = TraefikHostsExtractor(base_dir=tmp_path, env_vars={})
+
+        result = extractor.sync()
+
+        assert result == 0
+
+        # Verify the old IP was replaced with new HOSTIP
+        content = (hosts_dir / "hosts").read_text()
+        assert "192.168.1.10 svc.example.com" in content
+        assert "10.0.0.1" not in content
+
+    def test_preserves_comment_lines(self, tmp_path):
+        """Should preserve comment lines from existing hosts file."""
+        # Set up joyride as enabled
+        services_enabled = tmp_path / "services-enabled"
+        services_enabled.mkdir()
+        (services_enabled / "joyride.yml").write_text("# enabled")
+        (services_enabled / ".env").write_text("HOSTIP=192.168.1.10\nHOST_DOMAIN=example.com\n")
+        (services_enabled / ".env.external").write_text("SVC_HOST_NAME=svc\n")
+
+        # Create existing hosts file with comments
+        hosts_dir = tmp_path / "etc" / "joyride" / "hosts.d"
+        hosts_dir.mkdir(parents=True)
+        (hosts_dir / "hosts").write_text(
+            "# Manual entries\n"
+            "# Do not remove\n"
+            "192.168.1.50 manual.example.com\n"
+        )
+
+        # Create external config
+        external_enabled = tmp_path / "external-enabled"
+        external_enabled.mkdir()
+        (external_enabled / "service.yml").write_text(
+            traefik_yaml("svc", "SVC_HOST_NAME")
+        )
+
+        extractor = TraefikHostsExtractor(base_dir=tmp_path, env_vars={})
+
+        result = extractor.sync()
+
+        assert result == 0
+
+        # Verify comments are preserved
+        content = (hosts_dir / "hosts").read_text()
+        assert "# Manual entries" in content
+        assert "# Do not remove" in content
+        assert "manual.example.com" in content
+
+
+class TestSyncEarlyExit:
+    """Tests for sync early exit conditions."""
+
+    def test_exits_when_joyride_not_enabled(self, tmp_path, capsys):
+        """Should exit with error when joyride is not enabled."""
+        services_enabled = tmp_path / "services-enabled"
+        services_enabled.mkdir()
+        # No joyride.yml
+
+        extractor = TraefikHostsExtractor(base_dir=tmp_path)
+
+        result = extractor.sync()
+
+        assert result == 1
+
+        captured = capsys.readouterr()
+        assert "Joyride service is not enabled" in captured.err
+
+    def test_exits_when_hostip_not_set(self, tmp_path, capsys):
+        """Should exit with error when HOSTIP is not set."""
+        services_enabled = tmp_path / "services-enabled"
+        services_enabled.mkdir()
+        (services_enabled / "joyride.yml").write_text("# enabled")
+        (services_enabled / ".env").write_text("HOST_DOMAIN=example.com\n")
+
+        extractor = TraefikHostsExtractor(base_dir=tmp_path, env_vars={})
+
+        result = extractor.sync()
+
+        assert result == 1
+
+        captured = capsys.readouterr()
+        assert "HOSTIP not set" in captured.err
+
+    def test_exits_when_host_domain_not_set(self, tmp_path, capsys):
+        """Should exit with error when HOST_DOMAIN is not set."""
+        services_enabled = tmp_path / "services-enabled"
+        services_enabled.mkdir()
+        (services_enabled / "joyride.yml").write_text("# enabled")
+        (services_enabled / ".env").write_text("HOSTIP=192.168.1.10\n")
+
+        extractor = TraefikHostsExtractor(base_dir=tmp_path, env_vars={})
+
+        result = extractor.sync()
+
+        assert result == 1
+
+        captured = capsys.readouterr()
+        assert "HOST_DOMAIN not set" in captured.err
+
+
+class TestFullSync:
+    """Integration tests for full sync operation."""
+
+    def test_full_sync_creates_hosts_file(self, tmp_path, capsys):
+        """Should create hosts file with extracted entries."""
+        # Set up joyride as enabled
+        services_enabled = tmp_path / "services-enabled"
+        services_enabled.mkdir()
+        (services_enabled / "joyride.yml").write_text("# enabled")
+        (services_enabled / ".env").write_text(
+            "HOSTIP=192.168.1.10\n"
+            "HOST_DOMAIN=lab.local\n"
+        )
+        (services_enabled / ".env.external").write_text(
+            "HOMEASSISTANT_HOST_NAME=hass\n"
+            "PROXMOX_HOST_NAME=pve\n"
+        )
+
+        # Create external configs
+        external_enabled = tmp_path / "external-enabled"
+        external_enabled.mkdir()
+        (external_enabled / "homeassistant.yml").write_text(
+            traefik_yaml("hass", "HOMEASSISTANT_HOST_NAME")
+        )
+        (external_enabled / "proxmox.yml").write_text(
+            traefik_yaml("pve", "PROXMOX_HOST_NAME")
+        )
+
+        # Create hosts directory (simulating scaffold)
+        hosts_dir = tmp_path / "etc" / "joyride" / "hosts.d"
+        hosts_dir.mkdir(parents=True)
+
+        extractor = TraefikHostsExtractor(base_dir=tmp_path, env_vars={})
+
+        result = extractor.sync()
+
+        assert result == 0
+
+        # Verify hosts file was created
+        hosts_file = hosts_dir / "hosts"
+        assert hosts_file.exists()
+
+        content = hosts_file.read_text()
+        assert "192.168.1.10 hass.lab.local" in content
+        assert "192.168.1.10 pve.lab.local" in content
+
+        # Check output
+        captured = capsys.readouterr()
+        assert "Added:" in captured.out
+        assert "Wrote 2 host entries" in captured.out


### PR DESCRIPTION
Extract Host() rules from external-enabled/*.yml config files and generate hosts file entries for Joyride DNS ingestion.

Features:
- Early exit if Joyride service is not enabled
- Resolves {{env "VAR"}} Go template syntax from .env files
- FQDN-based deduplication preserves existing entries
- Excludes middleware-only config files
- Uses HOSTIP for all entries (Traefik proxies everything)

Usage: make traefik-sync-dns