### PR TITLE
fix(sietch): detect missing Docker image and rebuild automatically

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -85,6 +85,23 @@ Check logs for the specific error:
 docker logs --tail 100 containername
 ```
 
+## Sietch Container Issues
+
+### "Unable to find image 'sietch:latest' locally"
+
+**Cause:** The sietch container is a local-only image that must be built before use. It's commonly lost after running `docker system prune` or `docker image prune -a`.
+
+**Solution:**
+```bash
+make sietch-build
+```
+
+If that still fails (stale marker file):
+```bash
+rm -f sietch/.built
+make sietch-build
+```
+
 ## Environment Issues
 
 ### Variables not loading

--- a/make.d/sietch.mk
+++ b/make.d/sietch.mk
@@ -14,7 +14,12 @@ $(SIETCH_MARKER): $(SIETCH_FILES)
 	docker build -t $(SIETCH_IMAGE) ./sietch
 	@touch $(SIETCH_MARKER)
 
-sietch-build: $(SIETCH_MARKER) ## Build the Sietch tool container
+sietch-build: ## Build the Sietch tool container (auto-rebuilds if image missing or files changed)
+	@if ! docker image inspect $(SIETCH_IMAGE) >/dev/null 2>&1; then \
+		echo "Sietch image not found, forcing rebuild..."; \
+		rm -f $(SIETCH_MARKER); \
+	fi
+	@$(MAKE) $(SIETCH_MARKER)
 
 sietch-rebuild: ## Force rebuild of Sietch container
 	@echo "Force rebuilding Sietch container..."


### PR DESCRIPTION
The sietch-build target now checks if the Docker image exists before relying on the marker file. This prevents failures after docker system prune or docker image prune -a removes the local sietch image.

Adds troubleshooting documentation for the error message.