### PR TITLE
Make X-Robots-Tag middleware configurable per-service via env var

### DIFF
--- a/external-available/middleware.yml
+++ b/external-available/middleware.yml
@@ -12,7 +12,11 @@ http:
         stsSeconds: 15552000
         customFrameOptionsValue: SAMEORIGIN
         customResponseHeaders:
-          X-Robots-Tag: "none,noarchive,nosnippet,notranslate,noimageindex,"
           server: ""
         customRequestHeaders:
           X-Forwarded-Proto: https
+
+    noindex-headers:
+      headers:
+        customResponseHeaders:
+          X-Robots-Tag: "none,noarchive,nosnippet,notranslate,noimageindex,"

--- a/services-available/13ft.yml
+++ b/services-available/13ft.yml
@@ -27,6 +27,7 @@ services:
       - traefik.enable=${_13FT_TRAEFIK_ENABLED:-true}
       - traefik.http.routers.13ft.entrypoints=websecure
       - traefik.http.routers.13ft.rule=Host(`${_13FT_HOST_NAME:-13ft}.${HOST_DOMAIN}`)
+      - traefik.http.routers.13ft.middlewares=${_13FT_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.13ft.loadbalancer.server.port=5000
       - com.centurylinklabs.watchtower.enable=${_13FT_WATCHTOWER_ENABLED:-true}
       - autoheal=${_13FT_AUTOHEAL_ENABLED:-true}

--- a/services-available/actual.yml
+++ b/services-available/actual.yml
@@ -45,6 +45,7 @@ services:
       - traefik.enable=${ACTUAL_TRAEFIK_ENABLE:-true}
       - traefik.http.routers.actual.entrypoints=websecure
       - traefik.http.routers.actual.rule=Host(`${ACTUAL_CONTAINER_NAME:-actual}.${HOST_DOMAIN}`)
+      - traefik.http.routers.actual.middlewares=${ACTUAL_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.actual.loadbalancer.server.port=5006
       - com.centurylinklabs.watchtower.enable=${ACTUAL_WATCHTOWER_ENABLE:-true}
       - autoheal=${ACTUAL_AUTOHEAL:-true}

--- a/services-available/adguard.yml
+++ b/services-available/adguard.yml
@@ -37,6 +37,7 @@ services:
       - traefik.enable=${ADGUARD_TRAEFIK_ENABLED:-true}
       - traefik.http.routers.adguard.entrypoints=websecure
       - traefik.http.routers.adguard.rule=Host(`${ADGUARD_CONTAINER_NAME:-adguard}.${HOST_DOMAIN}`)
+      - traefik.http.routers.adguard.middlewares=${ADGUARD_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.adguard.loadbalancer.server.port=80
       - com.centurylinklabs.watchtower.enable=${ADGUARD_WATCHTOWER_ENABLED:-true}
       - autoheal=true

--- a/services-available/airprint.yml
+++ b/services-available/airprint.yml
@@ -30,6 +30,7 @@ services:
       - traefik.enable=true
       - traefik.http.routers.airprint.entrypoints=websecure
       - traefik.http.routers.airprint.rule=Host(`${AIRPRINT_CONTAINER_NAME:-airprint}.${HOST_DOMAIN}`)
+      - traefik.http.routers.airprint.middlewares=${AIRPRINT_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.airprint.loadbalancer.server.port=631
       - com.centurylinklabs.watchtower.enable=${AIRPRINT_WATCHTOWER_ENABLED:-true}
       - autoheal=true

--- a/services-available/apprise.yml
+++ b/services-available/apprise.yml
@@ -27,6 +27,7 @@ services:
       - traefik.enable=true
       - traefik.http.routers.apprise.entrypoints=websecure
       - traefik.http.routers.apprise.rule=Host(`${APPRISE_CONTAINER_NAME:-apprise}.${HOST_DOMAIN}`)
+      - traefik.http.routers.apprise.middlewares=${APPRISE_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       #- traefik.http.services.apprise.loadbalancer.server.scheme=https # enable if the service wants to connect over https
       - traefik.http.services.apprise.loadbalancer.server.port=8000
       - com.centurylinklabs.watchtower.enable=${APPRISE_WATCHTOWER_ENABLED:-true}

--- a/services-available/audiobookshelf.yml
+++ b/services-available/audiobookshelf.yml
@@ -31,6 +31,7 @@ services:
       - traefik.enable=true
       - traefik.http.routers.audiobookshelf.entrypoints=websecure
       - traefik.http.routers.audiobookshelf.rule=Host(`${AUDIOBOOKSHELF_CONTAINER_NAME:-audiobookshelf}.${HOST_DOMAIN}`)
+      - traefik.http.routers.audiobookshelf.middlewares=${AUDIOBOOKSHELF_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.audiobookshelf.loadbalancer.server.port=80
       - com.centurylinklabs.watchtower.enable=${AUDIOBOOKSHELF_WATCHTOWER_ENABLED:-true}
       - autoheal=true

--- a/services-available/authelia.yml
+++ b/services-available/authelia.yml
@@ -30,6 +30,7 @@ services:
       - traefik.enable=true
       - traefik.http.routers.authelia.rule=Host(`${AUTHELIA_AUTH_DOMAIN}`)
       - traefik.http.routers.authelia.entrypoints=websecure
+      - traefik.http.routers.authelia.middlewares=${AUTHELIA_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.middlewares.authelia.forwardauth.address=http://authelia:9091/api/verify?rd=${AUTHELIA_REDIR_DOMAIN}
       - traefik.http.middlewares.authelia.forwardauth.trustForwardHeader=true
       - traefik.http.middlewares.authelia.forwardauth.authResponseHeaders=Remote-User,Remote-Groups,Remote-Name,Remote-Email

--- a/services-available/authentik.yml
+++ b/services-available/authentik.yml
@@ -88,6 +88,7 @@ services:
       - traefik.enable=true
       - traefik.http.routers.authentik.entrypoints=websecure
       - traefik.http.routers.authentik.rule=Host(`${AUTHENTIK_AUTH_DOMAIN}`) || HostRegexp(`{subdomain:[a-z]+}.${HOST_DOMAIN}`) && PathPrefix(`/outpost.goauthentik.io/`)
+      - traefik.http.routers.authentik.middlewares=${AUTHENTIK_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.authentik.loadbalancer.server.port=9000
       - traefik.http.middlewares.authentik.forwardauth.address=http://authentik-server:9000/outpost.goauthentik.io/auth/traefik
       - traefik.http.middlewares.authentik.forwardauth.trustForwardHeader=true

--- a/services-available/basaran.yml
+++ b/services-available/basaran.yml
@@ -30,6 +30,7 @@ services:
       - traefik.enable=true
       - traefik.http.routers.basaran.entrypoints=websecure
       - traefik.http.routers.basaran.rule=Host(`${BASARAN_CONTAINER_NAME:-basaran}.${HOST_DOMAIN}`)
+      - traefik.http.routers.basaran.middlewares=${BASARAN_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       #- traefik.http.services.basaran.loadbalancer.server.scheme=https # enable if the service wants to connect over https
       - traefik.http.services.basaran.loadbalancer.server.port=80
       - com.centurylinklabs.watchtower.enable=${BASARAN_WATCHTOWER_ENABLED:-true}

--- a/services-available/bazarr.yml
+++ b/services-available/bazarr.yml
@@ -37,6 +37,7 @@ services:
       - traefik.enable=true
       - traefik.http.routers.bazarr.entrypoints=websecure
       - traefik.http.routers.bazarr.rule=Host(`${BAZARR_CONTAINER_NAME:-bazarr}.${HOST_DOMAIN}`)
+      - traefik.http.routers.bazarr.middlewares=${BAZARR_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.bazarr.loadbalancer.server.port=6767
       - com.centurylinklabs.watchtower.enable=${BAZARR_WATCHTOWER_ENABLED:-true}
       - autoheal=true

--- a/services-available/bentopdf.yml
+++ b/services-available/bentopdf.yml
@@ -35,6 +35,7 @@ services:
       - traefik.enable=${BENTOPDF_TRAEFIK_ENABLE:-true}
       - traefik.http.routers.bentopdf.entrypoints=websecure
       - traefik.http.routers.bentopdf.rule=Host(`${BENTOPDF_HOST_NAME:-bentopdf}.${HOST_DOMAIN}`)
+      - traefik.http.routers.bentopdf.middlewares=${BENTOPDF_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.bentopdf.loadbalancer.server.port=8080
       - com.centurylinklabs.watchtower.enable=${BENTOPDF_WATCHTOWER_ENABLE:-true}
       - autoheal=${BENTOPDF_AUTOHEAL:-true}

--- a/services-available/beszel-hub.yml
+++ b/services-available/beszel-hub.yml
@@ -29,6 +29,7 @@ services:
       - traefik.enable=${BESZEL_HUB_TRAEFIK_ENABLED:-true}
       - traefik.http.routers.beszel-hub.entrypoints=websecure
       - traefik.http.routers.beszel-hub.rule=Host(`${BESZEL_HUB_HOST_NAME:-beszel}.${HOST_DOMAIN}`)
+      - traefik.http.routers.beszel-hub.middlewares=${BESZEL_HUB_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       #- traefik.http.services.beszel-hub.loadbalancer.server.scheme=https # enable if the service wants to connect over https
       - traefik.http.services.beszel-hub.loadbalancer.server.port=8090
       - com.centurylinklabs.watchtower.enable=${BESZEL_HUB_WATCHTOWER_ENABLED:-true}

--- a/services-available/booklore.yml
+++ b/services-available/booklore.yml
@@ -36,6 +36,7 @@ services:
       - traefik.enable=${BOOKLORE_TRAEFIK_ENABLED:-true}
       - traefik.http.routers.booklore.entrypoints=websecure
       - traefik.http.routers.booklore.rule=Host(`${BOOKLORE_HOST_NAME:-booklore}.${HOST_DOMAIN}`)
+      - traefik.http.routers.booklore.middlewares=${BOOKLORE_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       #- traefik.http.services.booklore.loadbalancer.server.scheme=https # enable if the service wants to connect over https
       - traefik.http.services.booklore.loadbalancer.server.port=6060
       - com.centurylinklabs.watchtower.enable=${BOOKLORE_WATCHTOWER_ENABLED:-true}

--- a/services-available/bytebase.yml
+++ b/services-available/bytebase.yml
@@ -29,6 +29,7 @@ services:
       - traefik.enable=${BYTEBASE_TRAEFIK_ENABLED:-true}
       - traefik.http.routers.bytebase.entrypoints=websecure
       - traefik.http.routers.bytebase.rule=Host(`${BYTEBASE_HOST_NAME:-bytebase}.${HOST_DOMAIN}`)
+      - traefik.http.routers.bytebase.middlewares=${BYTEBASE_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       #- traefik.http.services.bytebase.loadbalancer.server.scheme=https # enable if the service wants to connect over https
       - traefik.http.services.bytebase.loadbalancer.server.port=8080
       - com.centurylinklabs.watchtower.enable=${BYTEBASE_WATCHTOWER_ENABLED:-true}

--- a/services-available/cadvisor.yml
+++ b/services-available/cadvisor.yml
@@ -38,4 +38,5 @@ services:
       - traefik.enable=true
       - traefik.http.routers.cadvisor.rule=Host(`${CADVISOR_CONTAINER_NAME:-cadvisor}.${HOST_DOMAIN}`)
       - traefik.http.routers.cadvisor.entrypoints=websecure
+      - traefik.http.routers.cadvisor.middlewares=${CADVISOR_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.cadvisor.loadbalancer.server.port=8080

--- a/services-available/chromadb.yml
+++ b/services-available/chromadb.yml
@@ -27,6 +27,7 @@ services:
       - traefik.enable=${CHROMADB_TRAEFIK_ENABLE:-true}
       - traefik.http.routers.chromadb.entrypoints=websecure
       - traefik.http.routers.chromadb.rule=Host(`${CHROMADB_CONTAINER_NAME:-chromadb}.${HOST_DOMAIN}`)
+      - traefik.http.routers.chromadb.middlewares=${CHROMADB_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.chromadb.loadbalancer.server.port=8000
       - com.centurylinklabs.watchtower.enable=${CHROMADB_WATCHTOWER_ENABLE:-true}
       - autoheal=${CHROMADB_AUTOHEAL:-true}

--- a/services-available/cially.yml
+++ b/services-available/cially.yml
@@ -64,6 +64,7 @@ services:
       - traefik.enable=${CIALLY_TRAEFIK_ENABLED:-true}
       - traefik.http.routers.cially.entrypoints=websecure
       - traefik.http.routers.cially.rule=Host(`${CIALLY_HOST_NAME:-cially}.${HOST_DOMAIN}`)
+      - traefik.http.routers.cially.middlewares=${CIALLY_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.cially.loadbalancer.server.port=3000
       - com.centurylinklabs.watchtower.enable=${CIALLY_WATCHTOWER_ENABLED:-true}
       - autoheal=${CIALLY_AUTOHEAL_ENABLED:-true}
@@ -86,6 +87,7 @@ services:
       - traefik.enable=${CIALLY_TRAEFIK_ENABLED:-true}
       - traefik.http.routers.cially-pb.entrypoints=websecure
       - traefik.http.routers.cially-pb.rule=Host(`${CIALLY_POCKETBASE_HOST_NAME:-cially-pb}.${HOST_DOMAIN}`)
+      - traefik.http.routers.cially-pb.middlewares=${CIALLY_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.cially-pb.loadbalancer.server.port=8090
       - com.centurylinklabs.watchtower.enable=${CIALLY_WATCHTOWER_ENABLED:-true}
       - autoheal=${CIALLY_AUTOHEAL_ENABLED:-true}

--- a/services-available/claude-connector.yml
+++ b/services-available/claude-connector.yml
@@ -31,6 +31,7 @@ services:
       - traefik.enable=${CLAUDE_CONNECTOR_TRAEFIK_ENABLED:-true}
       - traefik.http.routers.claude-connector.entrypoints=websecure
       - traefik.http.routers.claude-connector.rule=Host(`${CLAUDE_CONNECTOR_HOST_NAME:-claude-connector}.${HOST_DOMAIN}`)
+      - traefik.http.routers.claude-connector.middlewares=${CLAUDE_CONNECTOR_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.claude-connector.loadbalancer.server.port=8080
       - com.centurylinklabs.watchtower.enable=${CLAUDE_CONNECTOR_WATCHTOWER_ENABLED:-true}
       - autoheal=${CLAUDE_CONNECTOR_AUTOHEAL_ENABLED:-true}

--- a/services-available/cloudbeaver.yml
+++ b/services-available/cloudbeaver.yml
@@ -30,6 +30,7 @@ services:
       - traefik.enable=${CLOUDBEAVER_TRAEFIK_ENABLED:-true}
       - traefik.http.routers.cloudbeaver.entrypoints=websecure
       - traefik.http.routers.cloudbeaver.rule=Host(`${CLOUDBEAVER_HOST_NAME:-cloudbeaver}.${HOST_DOMAIN}`)
+      - traefik.http.routers.cloudbeaver.middlewares=${CLOUDBEAVER_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       #- traefik.http.services.cloudbeaver.loadbalancer.server.scheme=https # enable if the service wants to connect over https
       - traefik.http.services.cloudbeaver.loadbalancer.server.port=8978
       - com.centurylinklabs.watchtower.enable=${CLOUDBEAVER_WATCHTOWER_ENABLED:-true}

--- a/services-available/code-server.yml
+++ b/services-available/code-server.yml
@@ -30,6 +30,7 @@ services:
       - traefik.enable=true
       - traefik.http.routers.code-server.entrypoints=websecure
       - traefik.http.routers.code-server.rule=Host(`${CODE_SERVER_CONTAINER_NAME:-code-server}.${HOST_DOMAIN}`)
+      - traefik.http.routers.code-server.middlewares=${CODE_SERVER_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.code-server.loadbalancer.server.port=8443
       - com.centurylinklabs.watchtower.enable=${CODE_SERVER_WATCHTOWER_ENABLED:-true}
       - autoheal=true

--- a/services-available/comfyui.yml
+++ b/services-available/comfyui.yml
@@ -31,6 +31,7 @@ services:
       - traefik.enable=${COMFYUI_TRAEFIK_ENABLED:-true}
       - traefik.http.routers.comfyui.entrypoints=websecure
       - traefik.http.routers.comfyui.rule=Host(`${COMFYUI_HOST_NAME:-comfyui}.${HOST_DOMAIN}`)
+      - traefik.http.routers.comfyui.middlewares=${COMFYUI_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       #- traefik.http.services.comfyui.loadbalancer.server.scheme=https # enable if the service wants to connect over https
       - traefik.http.services.comfyui.loadbalancer.server.port=8188
       - com.centurylinklabs.watchtower.enable=${COMFYUI_WATCHTOWER_ENABLED:-true}

--- a/services-available/convertx.yml
+++ b/services-available/convertx.yml
@@ -29,6 +29,7 @@ services:
       - traefik.enable=${CONVERTX_TRAEFIK_ENABLED:-true}
       - traefik.http.routers.convertx.entrypoints=websecure
       - traefik.http.routers.convertx.rule=Host(`${CONVERTX_HOST_NAME:-convertx}.${HOST_DOMAIN}`)
+      - traefik.http.routers.convertx.middlewares=${CONVERTX_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       #- traefik.http.services.convertx.loadbalancer.server.scheme=https # enable if the service wants to connect over https
       - traefik.http.services.convertx.loadbalancer.server.port=3000
       - com.centurylinklabs.watchtower.enable=${CONVERTX_WATCHTOWER_ENABLED:-true}

--- a/services-available/copyparty.yml
+++ b/services-available/copyparty.yml
@@ -36,6 +36,7 @@ services:
       - traefik.enable=${COPYPARTY_TRAEFIK_ENABLED:-true}
       - traefik.http.routers.copyparty.entrypoints=websecure
       - traefik.http.routers.copyparty.rule=Host(`${COPYPARTY_HOST_NAME:-copyparty}.${HOST_DOMAIN}`)
+      - traefik.http.routers.copyparty.middlewares=${COPYPARTY_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       #- traefik.http.services.copyparty.loadbalancer.server.scheme=https # enable if the service wants to connect over https
       - traefik.http.services.copyparty.loadbalancer.server.port=3923
       - com.centurylinklabs.watchtower.enable=${COPYPARTY_WATCHTOWER_ENABLED:-true}

--- a/services-available/coqui-ai.yml
+++ b/services-available/coqui-ai.yml
@@ -30,6 +30,7 @@ services:
       - traefik.enable=true
       - traefik.http.routers.coqui-ai.entrypoints=websecure
       - traefik.http.routers.coqui-ai.rule=Host(`${COQUI_AI_CONTAINER_NAME:-coqui-ai}.${HOST_DOMAIN}`)
+      - traefik.http.routers.coqui-ai.middlewares=${COQUI_AI_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       #- traefik.http.services.coqui-ai.loadbalancer.server.scheme=https # enable if the service wants to connect over https
       - traefik.http.services.coqui-ai.loadbalancer.server.port=5002
       - com.centurylinklabs.watchtower.enable=${COQUI_WATCHTOWER_ENABLED:-true}

--- a/services-available/coredns.yml
+++ b/services-available/coredns.yml
@@ -40,6 +40,7 @@ services:
       - traefik.enable=${COREDNS_TRAEFIK_ENABLED:-true}
       - traefik.http.routers.coredns.entrypoints=websecure
       - traefik.http.routers.coredns.rule=Host(`${COREDNS_CONTAINER_NAME:-coredns}.${HOST_DOMAIN}`)
+      - traefik.http.routers.coredns.middlewares=${COREDNS_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.coredns.loadbalancer.server.port=80
       - com.centurylinklabs.watchtower.enable=${COREDNS_WATCHTOWER_ENABLED:-true}
       - autoheal=${COREDNS_AUTOHEAL_ENABLED:-true}

--- a/services-available/couchdb.yml
+++ b/services-available/couchdb.yml
@@ -32,6 +32,7 @@ services:
       - traefik.enable=${COUCHDB_TRAEFIK_ENABLED:-true}
       - traefik.http.routers.couchdb.entrypoints=websecure
       - traefik.http.routers.couchdb.rule=Host(`${COUCHDB_HOST_NAME:-couchdb}.${HOST_DOMAIN}`)
+      - traefik.http.routers.couchdb.middlewares=${COUCHDB_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       #- traefik.http.services.couchdb.loadbalancer.server.scheme=https # enable if the service wants to connect over https
       - traefik.http.services.couchdb.loadbalancer.server.port=5984
       - com.centurylinklabs.watchtower.enable=${COUCHDB_WATCHTOWER_ENABLED:-true}

--- a/services-available/cup.yml
+++ b/services-available/cup.yml
@@ -30,6 +30,7 @@ services:
       - traefik.enable=${CUP_TRAEFIK_ENABLED:-true}
       - traefik.http.routers.cup.entrypoints=websecure
       - traefik.http.routers.cup.rule=Host(`${CUP_HOST_NAME:-cup}.${HOST_DOMAIN}`)
+      - traefik.http.routers.cup.middlewares=${CUP_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       #- traefik.http.services.cup.loadbalancer.server.scheme=https # enable if the service wants to connect over https
       - traefik.http.services.cup.loadbalancer.server.port=9000
       - com.centurylinklabs.watchtower.enable=${CUP_WATCHTOWER_ENABLED:-true}

--- a/services-available/cv4pve.yml
+++ b/services-available/cv4pve.yml
@@ -27,6 +27,7 @@ services:
       - traefik.enable=true
       - traefik.http.routers.cv4pve.entrypoints=websecure
       - traefik.http.routers.cv4pve.rule=Host(`${CV4PVE_CONTAINER_NAME:-cv4pve}.${HOST_DOMAIN}`)
+      - traefik.http.routers.cv4pve.middlewares=${CV4PVE_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       #- traefik.http.services.cv4pve.loadbalancer.server.scheme=https # enable if the service wants to connect over https
       - traefik.http.services.cv4pve.loadbalancer.server.port=5000
       - com.centurylinklabs.watchtower.enable=${CV4PVE_WATCHTOWER_ENABLED:-true}

--- a/services-available/cyberchef.yml
+++ b/services-available/cyberchef.yml
@@ -19,6 +19,7 @@ services:
       - traefik.enable=true
       - traefik.http.routers.cyberchef.entrypoints=websecure
       - traefik.http.routers.cyberchef.rule=Host(`${CYBERCHEF_CONTAINER_NAME:-cyberchef}.${HOST_DOMAIN}`)
+      - traefik.http.routers.cyberchef.middlewares=${CYBERCHEF_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.cyberchef.loadbalancer.server.port=8000
       - com.centurylinklabs.watchtower.enable=${CYBERCHEF_WATCHTOWER_ENABLED:-true}
       - autoheal=true

--- a/services-available/dashdot.yml
+++ b/services-available/dashdot.yml
@@ -30,6 +30,7 @@ services:
       - traefik.enable=true
       - traefik.http.routers.dashdot.entrypoints=websecure
       - traefik.http.routers.dashdot.rule=Host(`${DASHDOT_CONTAINER_NAME:-dashdot}.${HOST_DOMAIN}`)
+      - traefik.http.routers.dashdot.middlewares=${DASHDOT_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.dashdot.loadbalancer.server.port=3001
       - com.centurylinklabs.watchtower.enable=${DASHDOT_WATCHTOWER_ENABLED:-true}
       - autoheal=true

--- a/services-available/dashy.yml
+++ b/services-available/dashy.yml
@@ -28,6 +28,7 @@ services:
       - traefik.enable=${DASHY_TRAEFIK_ENABLE:-true}
       - traefik.http.routers.dashy.entrypoints=websecure
       - traefik.http.routers.dashy.rule=Host(`${DASHY_CONTAINER_NAME:-dashy}.${HOST_DOMAIN}`)
+      - traefik.http.routers.dashy.middlewares=${DASHY_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.dashy.loadbalancer.server.port=80
       - com.centurylinklabs.watchtower.enable=${DASHY_WATCHTOWER_ENABLE:-true}
       - autoheal=${DASHY_AUTOHEAL:-true}

--- a/services-available/databasus.yml
+++ b/services-available/databasus.yml
@@ -33,6 +33,7 @@ services:
       - traefik.enable=${DATABASUS_TRAEFIK_ENABLE:-true}
       - traefik.http.routers.databasus.entrypoints=websecure
       - traefik.http.routers.databasus.rule=Host(`${DATABASUS_CONTAINER_NAME:-databasus}.${HOST_DOMAIN}`)
+      - traefik.http.routers.databasus.middlewares=${DATABASUS_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.databasus.loadbalancer.server.port=4005
       - com.centurylinklabs.watchtower.enable=${DATABASUS_WATCHTOWER_ENABLE:-true}
       - autoheal=${DATABASUS_AUTOHEAL:-true}

--- a/services-available/dawarich.yml
+++ b/services-available/dawarich.yml
@@ -79,6 +79,7 @@ services:
       - traefik.enable=${DAWARICH_TRAEFIK_ENABLED:-true}
       - traefik.http.routers.dawarich.entrypoints=websecure
       - traefik.http.routers.dawarich.rule=Host(`${DAWARICH_HOST_NAME:-dawarich}.${HOST_DOMAIN}`)
+      - traefik.http.routers.dawarich.middlewares=${DAWARICH_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       # - traefik.http.services.dawarich.loadbalancer.server.scheme=https # enable if the service wants to connect over https
       - traefik.http.services.dawarich.loadbalancer.server.port=3000
       - com.centurylinklabs.watchtower.enable=${DAWARICH_WATCHTOWER_ENABLED:-true}

--- a/services-available/docker-mirror.yml
+++ b/services-available/docker-mirror.yml
@@ -29,6 +29,7 @@ services:
       - traefik.enable=${DOCKER_MIRROR_TRAEFIK_ENABLED:-true}
       - traefik.http.routers.docker-mirror.entrypoints=websecure
       - traefik.http.routers.docker-mirror.rule=Host(`${DOCKER_MIRROR_HOST_NAME:-docker-mirror}.${HOST_DOMAIN}`)
+      - traefik.http.routers.docker-mirror.middlewares=${DOCKER_MIRROR_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       #- traefik.http.services.docker-mirror.loadbalancer.server.scheme=https # enable if the service wants to connect over https
       - traefik.http.services.docker-mirror.loadbalancer.server.port=5000
       - com.centurylinklabs.watchtower.enable=${DOCKER_MIRROR_WATCHTOWER_ENABLED:-true}

--- a/services-available/docker-registry.yml
+++ b/services-available/docker-registry.yml
@@ -29,6 +29,7 @@ services:
       - traefik.enable=${DOCKER_REGISTRY_TRAEFIK_ENABLED:-true}
       - traefik.http.routers.registry.entrypoints=websecure
       - traefik.http.routers.registry.rule=Host(`${DOCKER_REGISTRY_CONTAINER_NAME:-registry}.${HOST_DOMAIN}`)
+      - traefik.http.routers.registry.middlewares=${DOCKER_REGISTRY_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.registry.loadbalancer.server.port=5000
       # https://bcrypt-generator.com/ Generate DOCKER_REGISTRY_AUTH_PASS - make sure you double up the $$ to escape them
       - traefik.http.middlewares.auth.basicauth.users=${DOCKER_REGISTRY_AUTH_USER:-admin}:${DOCKER_REGISTRY_AUTH_PASS:-password}}

--- a/services-available/dockerizalo.yml
+++ b/services-available/dockerizalo.yml
@@ -24,6 +24,7 @@ services:
       - traefik.docker.network=traefik
       - traefik.http.routers.dockerizalo.entrypoints=websecure
       - traefik.http.routers.dockerizalo.rule=Host(`${DOCKERIZALO_PROXY_CONTAINER_NAME:-dockerizalo}.${HOST_DOMAIN}`)
+      - traefik.http.routers.dockerizalo.middlewares=${DOCKERIZALO_PROXY_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.dockerizalo.loadbalancer.server.port=8080
       - com.centurylinklabs.watchtower.enable=${DOCKERIZALO_PROXY_WATCHTOWER_ENABLED:-true}
       - autoheal=${DOCKERIZALO_PROXY_AUTOHEAL_ENABLED:-true}

--- a/services-available/dockpeek.yml
+++ b/services-available/dockpeek.yml
@@ -41,6 +41,7 @@ services:
       - traefik.enable=${DOCKPEEK_TRAEFIK_ENABLED:-true}
       - traefik.http.routers.dockpeek.entrypoints=websecure
       - traefik.http.routers.dockpeek.rule=Host(`${DOCKPEEK_HOST_NAME:-dockpeek}.${HOST_DOMAIN}`)
+      - traefik.http.routers.dockpeek.middlewares=${DOCKPEEK_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       #- traefik.http.services.dockpeek.loadbalancer.server.scheme=https # enable if the service wants to connect over https
       - traefik.http.services.dockpeek.loadbalancer.server.port=8000
       - com.centurylinklabs.watchtower.enable=${DOCKPEEK_WATCHTOWER_ENABLED:-true}

--- a/services-available/docling.yml
+++ b/services-available/docling.yml
@@ -42,6 +42,7 @@ services:
       - traefik.enable=${DOCLING_TRAEFIK_ENABLE:-true}
       - traefik.http.routers.docling.entrypoints=websecure
       - traefik.http.routers.docling.rule=Host(`${DOCLING_CONTAINER_NAME:-docling}.${HOST_DOMAIN}`)
+      - traefik.http.routers.docling.middlewares=${DOCLING_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.docling.loadbalancer.server.port=5001
       - com.centurylinklabs.watchtower.enable=${DOCLING_WATCHTOWER_ENABLE:-true}
       - autoheal=${DOCLING_AUTOHEAL:-true}

--- a/services-available/docmost.yml
+++ b/services-available/docmost.yml
@@ -34,6 +34,7 @@ services:
       - traefik.enable=${DOCMOST_TRAEFIK_ENABLED:-true}
       - traefik.http.routers.docmost.entrypoints=websecure
       - traefik.http.routers.docmost.rule=Host(`${DOCMOST_CONTAINER_NAME:-docmost}.${HOST_DOMAIN}`)
+      - traefik.http.routers.docmost.middlewares=${DOCMOST_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       #- traefik.http.services.docmost.loadbalancer.server.scheme=https # enable if the service wants to connect over https
       - traefik.http.services.docmost.loadbalancer.server.port=3000
       - com.centurylinklabs.watchtower.enable=${DOCMOST_WATCHTOWER_ENABLED:-true}

--- a/services-available/doku.yml
+++ b/services-available/doku.yml
@@ -29,6 +29,7 @@ services:
       - traefik.enable=${DOKU_TRAEFIK_ENABLED:-true}
       - traefik.http.routers.doku.entrypoints=websecure
       - traefik.http.routers.doku.rule=Host(`${DOKU_CONTAINER_NAME:-doku}.${HOST_DOMAIN}`)
+      - traefik.http.routers.doku.middlewares=${DOKU_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.doku.loadbalancer.server.port=9090
       - com.centurylinklabs.watchtower.enable=${DOKU_WATCHTOWER_ENABLED:-true}
       - autoheal=${DOKU_AUTOHEAL_ENABLED:-true}

--- a/services-available/dozzle-path.yml
+++ b/services-available/dozzle-path.yml
@@ -24,6 +24,7 @@ services:
       - traefik.enable=true
       - traefik.http.routers.dozzle.rule=PathPrefix(`${DOZZLE_BASE:-/logs}`)
       - traefik.http.routers.dozzle.entrypoints=websecure
+      - traefik.http.routers.dozzle.middlewares=${DOZZLE_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.dozzle.loadbalancer.server.scheme=http
       - traefik.http.services.dozzle.loadbalancer.server.port=8080
       - com.centurylinklabs.watchtower.enable=${DOZZLE_WATCHTOWER_ENABLED:-true}

--- a/services-available/dozzle.yml
+++ b/services-available/dozzle.yml
@@ -27,6 +27,7 @@ services:
       - traefik.enable=${DOZZLE_TRAEFIK_ENABLE:-true}
       - traefik.http.routers.dozzle.entrypoints=websecure
       - traefik.http.routers.dozzle.rule=Host(`${DOZZLE_CONTAINER_NAME:-dozzle}.${HOST_DOMAIN}`)
+      - traefik.http.routers.dozzle.middlewares=${DOZZLE_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.dozzle.loadbalancer.server.port=8080
       - com.centurylinklabs.watchtower.enable=${DOZZLE_WATCHTOWER_ENABLE:-true}
       - autoheal=${DOZZLE_AUTOHEAL:-true}

--- a/services-available/drawio.yml
+++ b/services-available/drawio.yml
@@ -30,6 +30,7 @@ services:
       - traefik.enable=true
       - traefik.http.routers.drawio.entrypoints=websecure
       - traefik.http.routers.drawio.rule=Host(`${DRAW_IO_CONTAINER_NAME:-drawio}.${HOST_DOMAIN}`)
+      - traefik.http.routers.drawio.middlewares=${DRAW_IO_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.drawio.loadbalancer.server.port=8080
       - com.centurylinklabs.watchtower.enable=${DRAW_IO_WATCHTOWER_ENABLED:-true}
       - autoheal=true

--- a/services-available/droneci.yml
+++ b/services-available/droneci.yml
@@ -44,6 +44,7 @@ services:
       - traefik.enable=true
       - traefik.http.routers.drone.rule=Host(`${DRONE_CONTAINER_NAME:-drone}.${HOST_DOMAIN}`)
       - traefik.http.routers.drone.entrypoints=websecure
+      - traefik.http.routers.drone.middlewares=${DRONE_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.drone.loadbalancer.server.port=80
       - com.centurylinklabs.watchtower.enable=${DRONE_WATCHTOWER_ENABLED:-true}
       - autoheal=true

--- a/services-available/duplicati.yml
+++ b/services-available/duplicati.yml
@@ -30,6 +30,7 @@ services:
       - traefik.enable=true
       - traefik.http.routers.duplicati.entrypoints=websecure
       - traefik.http.routers.duplicati.rule=Host(`${DUPLICATI_HOST_NAME:-duplicati}.${HOST_DOMAIN}`)
+      - traefik.http.routers.duplicati.middlewares=${DUPLICATI_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.duplicati.loadbalancer.server.port=8200
       - com.centurylinklabs.watchtower.enable=${DUPLICATI_WATCHTOWER_ENABLED:-true}
       - autoheal=true

--- a/services-available/excalidraw.yml
+++ b/services-available/excalidraw.yml
@@ -34,6 +34,7 @@ services:
       - traefik.enable=true
       - traefik.http.routers.excalidraw.entrypoints=websecure
       - traefik.http.routers.excalidraw.rule=Host(`${EXCALIDRAW_CONTAINER_NAME:-excalidraw}.${HOST_DOMAIN}`)
+      - traefik.http.routers.excalidraw.middlewares=${EXCALIDRAW_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.excalidraw.loadbalancer.server.port=80
       - com.centurylinklabs.watchtower.enable=${EXCALIDRAW_WATCHTOWER_ENABLED:-true}
       - autoheal=true

--- a/services-available/feishin.yml
+++ b/services-available/feishin.yml
@@ -31,7 +31,7 @@ services:
       - traefik.enable=${FEISHIN_TRAEFIK_ENABLED:-true}
       - traefik.http.routers.feishin.entrypoints=websecure
       - traefik.http.routers.feishin.rule=Host(`${FEISHIN_HOST_NAME:-feishin}.${HOST_DOMAIN}`)
-      - traefik.http.routers.feishin.middlewares=default-headers@file
+      - traefik.http.routers.feishin.middlewares=${FEISHIN_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.feishin.loadbalancer.server.port=9180
       - com.centurylinklabs.watchtower.enable=${FEISHIN_WATCHTOWER_ENABLED:-true}
       - autoheal=${FEISHIN_AUTOHEAL_ENABLED:-true}

--- a/services-available/firefly-data-importer.yml
+++ b/services-available/firefly-data-importer.yml
@@ -35,6 +35,7 @@ services:
       - traefik.enable=true
       - traefik.http.routers.firefly-data-importer.entrypoints=websecure
       - traefik.http.routers.firefly-data-importer.rule=Host(`${FIREFLY_DATA_IMPORTER_CONTAINER_NAME:-firefly-importer}.${HOST_DOMAIN}`)
+      - traefik.http.routers.firefly-data-importer.middlewares=${FIREFLY_DATA_IMPORTER_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.firefly-data-importer.loadbalancer.server.port=8080
       - com.centurylinklabs.watchtower.enable=${FIREFLY_DATA_IMPORTER_WATCHTOWER_ENABLED:-true}
       - autoheal=true

--- a/services-available/firefly3.yml
+++ b/services-available/firefly3.yml
@@ -54,6 +54,7 @@ services:
       - traefik.docker.network=traefik
       - traefik.http.routers.firefly3.entrypoints=websecure
       - traefik.http.routers.firefly3.rule=Host(`${FIREFLY3_CONTAINER_NAME:-firefly}.${HOST_DOMAIN}`)
+      - traefik.http.routers.firefly3.middlewares=${FIREFLY3_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.firefly3.loadbalancer.server.port=8080
       - com.centurylinklabs.watchtower.enable=${FIREFLY3_WATCHTOWER_ENABLED:-true}
       - autoheal=true

--- a/services-available/firefox.yml
+++ b/services-available/firefox.yml
@@ -33,6 +33,7 @@ services:
       - traefik.enable=${FIREFOX_TRAEFIK_ENABLE:-true}
       - traefik.http.routers.firefox.entrypoints=websecure
       - traefik.http.routers.firefox.rule=Host(`${FIREFOX_CONTAINER_NAME:-firefox}.${HOST_DOMAIN}`)
+      - traefik.http.routers.firefox.middlewares=${FIREFOX_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       #- traefik.http.services.firefox.loadbalancer.server.scheme=https # enable if the service wants to connect over https
       - traefik.http.services.firefox.loadbalancer.server.port=3000
       - com.centurylinklabs.watchtower.enable=${FIREFOX_WATCHTOWER_ENABLE:-true}

--- a/services-available/flame.yml
+++ b/services-available/flame.yml
@@ -29,6 +29,7 @@ services:
       - traefik.enable=true
       - traefik.http.routers.flame.entrypoints=websecure
       - traefik.http.routers.flame.rule=Host(`${FLAME_CONTAINER_NAME:-flame}.${HOST_DOMAIN}`)
+      - traefik.http.routers.flame.middlewares=${FLAME_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.flame.loadbalancer.server.port=5005
       - com.centurylinklabs.watchtower.enable=${FLAME_WATCHTOWER_ENABLED:-true}
       - autoheal=true

--- a/services-available/flightcheck.yml
+++ b/services-available/flightcheck.yml
@@ -51,6 +51,7 @@ services:
       - traefik.enable=${FLIGHTCHECK_TRAEFIK_ENABLED:-true}
       - traefik.http.routers.flightcheck.entrypoints=websecure
       - traefik.http.routers.flightcheck.rule=Host(`${FLIGHTCHECK_HOST_NAME:-flightcheck}.${HOST_DOMAIN}`)
+      - traefik.http.routers.flightcheck.middlewares=${FLIGHTCHECK_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.flightcheck.loadbalancer.server.port=8000
       - com.centurylinklabs.watchtower.enable=${FLIGHTCHECK_WATCHTOWER_ENABLED:-true}
       - autoheal=${FLIGHTCHECK_AUTOHEAL_ENABLED:-true}

--- a/services-available/fooocus.yml
+++ b/services-available/fooocus.yml
@@ -40,6 +40,7 @@ services:
       - traefik.enable=${FOOOCUS_TRAEFIK_ENABLED:-true}
       - traefik.http.routers.fooocus.entrypoints=websecure
       - traefik.http.routers.fooocus.rule=Host(`${FOOOCUS_HOST_NAME:-fooocus}.${HOST_DOMAIN}`)
+      - traefik.http.routers.fooocus.middlewares=${FOOOCUS_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       #- traefik.http.services.fooocus.loadbalancer.server.scheme=https # enable if the service wants to connect over https
       - traefik.http.services.fooocus.loadbalancer.server.port=7865
       - com.centurylinklabs.watchtower.enable=${FOOOCUS_WATCHTOWER_ENABLED:-true}

--- a/services-available/forgejo.yml
+++ b/services-available/forgejo.yml
@@ -35,6 +35,7 @@ services:
       - traefik.enable=${FORGEJO_TRAEFIK_ENABLE:-true}
       - traefik.http.routers.forgejo.entrypoints=websecure
       - traefik.http.routers.forgejo.rule=Host(`${FORGEJO_CONTAINER_NAME:-forgejo}.${HOST_DOMAIN}`)
+      - traefik.http.routers.forgejo.middlewares=${FORGEJO_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.forgejo.loadbalancer.server.port=3000
       - com.centurylinklabs.watchtower.enable=${FORGEJO_WATCHTOWER_ENABLE:-true}
       - autoheal=${FORGEJO_AUTOHEAL:-true}

--- a/services-available/fossflow.yml
+++ b/services-available/fossflow.yml
@@ -29,6 +29,7 @@ services:
       - traefik.enable=${FOSSFLOW_TRAEFIK_ENABLED:-true}
       - traefik.http.routers.fossflow.entrypoints=websecure
       - traefik.http.routers.fossflow.rule=Host(`${FOSSFLOW_HOST_NAME:-fossflow}.${HOST_DOMAIN}`)
+      - traefik.http.routers.fossflow.middlewares=${FOSSFLOW_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       #- traefik.http.services.fossflow.loadbalancer.server.scheme=https # enable if the service wants to connect over https
       - traefik.http.services.fossflow.loadbalancer.server.port=3000
       - com.centurylinklabs.watchtower.enable=${FOSSFLOW_WATCHTOWER_ENABLED:-true}

--- a/services-available/foundryvtt.yml
+++ b/services-available/foundryvtt.yml
@@ -29,6 +29,7 @@ services:
       - traefik.enable=true
       - traefik.http.routers.foundryvtt.entrypoints=websecure
       - traefik.http.routers.foundryvtt.rule=Host(`${FOUNDRYVTT_CONTAINER_NAME:-foundryvtt}.${HOST_DOMAIN}`)
+      - traefik.http.routers.foundryvtt.middlewares=${FOUNDRYVTT_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.foundryvtt.loadbalancer.server.port=30000
       - com.centurylinklabs.watchtower.enable=${FOUNDRYVTT_WATCHTOWER_ENABLED:-true}
       - autoheal=true

--- a/services-available/freshrss.yml
+++ b/services-available/freshrss.yml
@@ -28,6 +28,7 @@ services:
       - traefik.enable=true
       - traefik.http.routers.freshrss.entrypoints=websecure
       - traefik.http.routers.freshrss.rule=Host(`${FRESHRSS_CONTAINER_NAME:-freshrss}.${HOST_DOMAIN}`)
+      - traefik.http.routers.freshrss.middlewares=${FRESHRSS_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.freshrss.loadbalancer.server.port=80
       - com.centurylinklabs.watchtower.enable=${FRESHRSS_WATCHTOWER_ENABLED:-true}
       - autoheal=true

--- a/services-available/frigate-coral.yml
+++ b/services-available/frigate-coral.yml
@@ -38,6 +38,7 @@ services:
       - traefik.enable=${FRIGATE_TRAEFIK_ENABLE:-true}
       - traefik.http.routers.frigate.entrypoints=websecure
       - traefik.http.routers.frigate.rule=Host(`${FRIGATE_HOST_NAME:-frigate}.${HOST_DOMAIN}`)
+      - traefik.http.routers.frigate.middlewares=${FRIGATE_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.frigate.loadbalancer.server.port=5000
       - com.centurylinklabs.watchtower.enable=${FRIGATE_WATCHTOWER_ENABLE:-true}
       - autoheal=${FRIGATE_AUTOHEAL:-true}

--- a/services-available/frigate-cpu.yml
+++ b/services-available/frigate-cpu.yml
@@ -36,6 +36,7 @@ services:
       - traefik.enable=${FRIGATE_TRAEFIK_ENABLE:-true}
       - traefik.http.routers.frigate.entrypoints=websecure
       - traefik.http.routers.frigate.rule=Host(`${FRIGATE_HOST_NAME:-frigate}.${HOST_DOMAIN}`)
+      - traefik.http.routers.frigate.middlewares=${FRIGATE_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.frigate.loadbalancer.server.port=5000
       - com.centurylinklabs.watchtower.enable=${FRIGATE_WATCHTOWER_ENABLE:-true}
       - autoheal=${FRIGATE_AUTOHEAL:-true}

--- a/services-available/frigate-nvidia.yml
+++ b/services-available/frigate-nvidia.yml
@@ -50,6 +50,7 @@ services:
       - traefik.enable=true
       - traefik.http.routers.frigate.entrypoints=websecure
       - traefik.http.routers.frigate.rule=Host(`${FRIGATE_CONTAINER_NAME:-frigate}.${HOST_DOMAIN}`)
+      - traefik.http.routers.frigate.middlewares=${FRIGATE_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.frigate.loadbalancer.server.port=5000
       - com.centurylinklabs.watchtower.enable=${FRIGATE_WATCHTOWER_ENABLED:-true}
       - autoheal=true

--- a/services-available/fulltext-rss.yml
+++ b/services-available/fulltext-rss.yml
@@ -27,6 +27,7 @@ services:
       - traefik.enable=true
       - traefik.http.routers.fulltext-rss.entrypoints=websecure
       - traefik.http.routers.fulltext-rss.rule=Host(`${FULLTEXT_RSS_CONTAINER_NAME:-fulltext-rss}.${HOST_DOMAIN}`)
+      - traefik.http.routers.fulltext-rss.middlewares=${FULLTEXT_RSS_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.fulltext-rss.loadbalancer.server.port=8096
       - com.centurylinklabs.watchtower.enable=${FULLTEXT_RSS_WATCHTOWER_ENABLED:-true}
       - autoheal=true

--- a/services-available/garage.yml
+++ b/services-available/garage.yml
@@ -117,6 +117,7 @@ services:
       - traefik.http.routers.garage-s3.tls=true
       - traefik.http.routers.garage-s3.rule=Host(`${GARAGE_S3_HOST:-s3}.${HOST_DOMAIN}`)
       - traefik.http.routers.garage-s3.service=garage-s3-backend
+      - traefik.http.routers.garage-s3.middlewares=${GARAGE_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.garage-s3-backend.loadbalancer.server.port=${GARAGE_S3_PORT:-3900}
 
       # Also route bucket subdomains to S3 API (for virtual-hosted style access)
@@ -124,12 +125,14 @@ services:
       - traefik.http.routers.garage-s3-buckets.tls=true
       - traefik.http.routers.garage-s3-buckets.rule=HostRegexp(`{subdomain:[a-z0-9-]+}.${GARAGE_S3_HOST:-s3}.${HOST_DOMAIN}`)
       - traefik.http.routers.garage-s3-buckets.service=garage-s3-backend
+      - traefik.http.routers.garage-s3-buckets.middlewares=${GARAGE_MIDDLEWARES:-default-headers@file,noindex-headers@file}
 
       # Admin API service settings (metrics, cluster status, key management)
       - traefik.http.routers.garage-admin.entrypoints=websecure
       - traefik.http.routers.garage-admin.tls=true
       - traefik.http.routers.garage-admin.rule=Host(`${GARAGE_ADMIN_HOST:-garage}.${HOST_DOMAIN}`)
       - traefik.http.routers.garage-admin.service=garage-admin-backend
+      - traefik.http.routers.garage-admin.middlewares=${GARAGE_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.garage-admin-backend.loadbalancer.server.port=${GARAGE_ADMIN_PORT:-3903}
 
       - com.centurylinklabs.watchtower.enable=${GARAGE_WATCHTOWER_ENABLED:-true}

--- a/services-available/gatus.yml
+++ b/services-available/gatus.yml
@@ -30,6 +30,7 @@ services:
       - traefik.enable=true
       - traefik.http.routers.gatus.entrypoints=websecure
       - traefik.http.routers.gatus.rule=Host(`${GATUS_CONTAINER_NAME:-gatus}.${HOST_DOMAIN}`)
+      - traefik.http.routers.gatus.middlewares=${GATUS_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       #- traefik.http.services.gatus.loadbalancer.server.scheme=https # enable if the service wants to connect over https
       - traefik.http.services.gatus.loadbalancer.server.port=8080
       - com.centurylinklabs.watchtower.enable=${GATUS_WATCHTOWER_ENABLED:-true}

--- a/services-available/geopulse.yml
+++ b/services-available/geopulse.yml
@@ -141,6 +141,7 @@ services:
       - traefik.enable=${GEOPULSE_TRAEFIK_ENABLED:-true}
       - traefik.http.routers.geopulse.entrypoints=websecure
       - traefik.http.routers.geopulse.rule=Host(`${GEOPULSE_HOST_NAME:-geopulse}.${HOST_DOMAIN}`)
+      - traefik.http.routers.geopulse.middlewares=${GEOPULSE_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.geopulse.loadbalancer.server.port=80
       - com.centurylinklabs.watchtower.enable=${GEOPULSE_WATCHTOWER_ENABLED:-true}
       - autoheal=${GEOPULSE_AUTOHEAL_ENABLED:-true}

--- a/services-available/ghost.yml
+++ b/services-available/ghost.yml
@@ -32,6 +32,7 @@ services:
       - traefik.enable=true
       - traefik.http.routers.ghost.entrypoints=websecure
       - traefik.http.routers.ghost.rule=Host(`${GHOST_CONTAINER_NAME:-ghost}.${HOST_DOMAIN}`)
+      - traefik.http.routers.ghost.middlewares=${GHOST_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.ghost.loadbalancer.server.port=2368
       - com.centurylinklabs.watchtower.enable=${GHOST_WATCHTOWER_ENABLED:-true}
       - autoheal=true

--- a/services-available/gitea.yml
+++ b/services-available/gitea.yml
@@ -38,6 +38,7 @@ services:
       - traefik.enable=true
       - traefik.http.routers.gitea.rule=Host(`${GITEA_CONTAINER_NAME:-gitea}.${HOST_DOMAIN}`)
       - traefik.http.routers.gitea.entrypoints=websecure
+      - traefik.http.routers.gitea.middlewares=${GITEA_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.gitea.loadbalancer.server.port=4000
       - com.centurylinklabs.watchtower.enable=${GITEA_WATCHTOWER_ENABLED:-true}
       - autoheal=true

--- a/services-available/gitlab.yml
+++ b/services-available/gitlab.yml
@@ -36,6 +36,7 @@ services:
       - traefik.http.routers.gitlab.rule=Host(`${GITLAB_CONTAINER_NAME:-gitlab}.${HOST_DOMAIN}`)
       - traefik.http.routers.gitlab.tls=true
       - traefik.http.routers.gitlab.service=gitlab
+      - traefik.http.routers.gitlab.middlewares=${GITLAB_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.gitlab.loadbalancer.server.scheme=https
       - traefik.http.services.gitlab.loadbalancer.server.port=443
       - com.centurylinklabs.watchtower.enable=${GITLAB_WATCHTOWER_ENABLED:-true}

--- a/services-available/glance.yml
+++ b/services-available/glance.yml
@@ -29,6 +29,7 @@ services:
       - traefik.enable=${GLANCE_TRAEFIK_ENABLED:-true}
       - traefik.http.routers.glance.entrypoints=websecure
       - traefik.http.routers.glance.rule=Host(`${GLANCE_HOST_NAME:-glance}.${HOST_DOMAIN}`)
+      - traefik.http.routers.glance.middlewares=${GLANCE_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       #- traefik.http.services.glance.loadbalancer.server.scheme=https # enable if the service wants to connect over https
       - traefik.http.services.glance.loadbalancer.server.port=8080
       - com.centurylinklabs.watchtower.enable=${GLANCE_WATCHTOWER_ENABLED:-true}

--- a/services-available/glances.yml
+++ b/services-available/glances.yml
@@ -29,6 +29,7 @@ services:
       - traefik.enable=true
       - traefik.http.routers.glances.entrypoints=websecure
       - traefik.http.routers.glances.rule=Host(`${GLANCES_CONTAINER_NAME:-glances}.${HOST_DOMAIN}`)
+      - traefik.http.routers.glances.middlewares=${GLANCES_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.glances.loadbalancer.server.port=61208
       - com.centurylinklabs.watchtower.enable=${GLANCES_WATCHTOWER_ENABLED:-true}
       - autoheal=true

--- a/services-available/go2rtc.yml
+++ b/services-available/go2rtc.yml
@@ -31,6 +31,7 @@ services:
       - traefik.enable=true
       - traefik.http.routers.go2rtc.entrypoints=websecure
       - traefik.http.routers.go2rtc.rule=Host(`${GO2RTC_CONTAINER_NAME:-go2rtc}.${HOST_DOMAIN}`)
+      - traefik.http.routers.go2rtc.middlewares=${GO2RTC_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       #- traefik.http.services.go2rtc.loadbalancer.server.scheme=https # enable if the service wants to connect over https
       - traefik.http.services.go2rtc.loadbalancer.server.port=1984
       - com.centurylinklabs.watchtower.enable=${GO2RTC_WATCHTOWER_ENABLED:-true}

--- a/services-available/gotify.yml
+++ b/services-available/gotify.yml
@@ -27,6 +27,7 @@ services:
       - traefik.enable=true
       - traefik.http.routers.gotify.entrypoints=websecure
       - traefik.http.routers.gotify.rule=Host(`${GOTIFY_CONTAINER_NAME:-gotify}.${HOST_DOMAIN}`)
+      - traefik.http.routers.gotify.middlewares=${GOTIFY_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.gotify.loadbalancer.server.port=80
       - com.centurylinklabs.watchtower.enable=${GOTIFY_WATCHTOWER_ENABLED:-true}
       - autoheal=true

--- a/services-available/grafana.yml
+++ b/services-available/grafana.yml
@@ -30,4 +30,5 @@ services:
       - traefik.docker.network=traefik
       - traefik.http.routers.grafana.rule=Host(`${GRAFANA_CONTAINER_NAME:-grafana}.${HOST_DOMAIN}`)
       - traefik.http.routers.grafana.entrypoints=websecure
+      - traefik.http.routers.grafana.middlewares=${GRAFANA_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.grafana.loadbalancer.server.port=3000

--- a/services-available/grocy.yml
+++ b/services-available/grocy.yml
@@ -26,6 +26,7 @@ services:
       - traefik.enable=${GROCY_TRAEFIK_ENABLE:-true}
       - traefik.http.routers.grocy.entrypoints=websecure
       - traefik.http.routers.grocy.rule=Host(`${GROCY_CONTAINER_NAME:-grocy}.${HOST_DOMAIN}`)
+      - traefik.http.routers.grocy.middlewares=${GROCY_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.grocy.loadbalancer.server.port=80
       - com.centurylinklabs.watchtower.enable=${GROCY_WATCHTOWER_ENABLE:-true}
       - autoheal=${GROCY_AUTOHEAL:-true}

--- a/services-available/guacamole.yml
+++ b/services-available/guacamole.yml
@@ -29,6 +29,7 @@ services:
       - traefik.enable=${GUACAMOLE_TRAEFIK_ENABLED:-true}
       - traefik.http.routers.guacamole.entrypoints=websecure
       - traefik.http.routers.guacamole.rule=Host(`${GUACAMOLE_CONTAINER_NAME:-guacamole}.${HOST_DOMAIN}`)
+      - traefik.http.routers.guacamole.middlewares=${GUACAMOLE_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.guacamole.loadbalancer.server.port=8080
       - com.centurylinklabs.watchtower.enable=${GUACAMOLE_WATCHTOWER_ENABLED:-true}
       - autoheal=${GUACAMOLE_AUTOHEAL_ENABLED:-true}

--- a/services-available/headphones.yml
+++ b/services-available/headphones.yml
@@ -29,6 +29,7 @@ services:
       - traefik.enable=${HEADPHONES_TRAEFIK_ENABLED:-true}
       - traefik.http.routers.headphones.entrypoints=websecure
       - traefik.http.routers.headphones.rule=Host(`${HEADPHONES_HOST_NAME:-headphones}.${HOST_DOMAIN}`)
+      - traefik.http.routers.headphones.middlewares=${HEADPHONES_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       #- traefik.http.services.headphones.loadbalancer.server.scheme=https # enable if the service wants to connect over https
       - traefik.http.services.headphones.loadbalancer.server.port=8181
       - com.centurylinklabs.watchtower.enable=${HEADPHONES_WATCHTOWER_ENABLED:-true}

--- a/services-available/healthchecks.yml
+++ b/services-available/healthchecks.yml
@@ -50,7 +50,7 @@ services:
       - traefik.http.routers.healthchecks.entrypoints=websecure
       - traefik.http.routers.healthchecks.rule=Host(`${HEALTHCHECKS_CONTAINER_NAME:-healthchecks}.${HOST_DOMAIN}`)
       - traefik.http.services.healthchecks.loadbalancer.server.port=8000
-      - traefik.http.routers.healthchecks.middlewares=default-headers@file
+      - traefik.http.routers.healthchecks.middlewares=${HEALTHCHECKS_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - com.centurylinklabs.watchtower.enable=${HEALTHCHECKS_WATCHTOWER_ENABLED:-true}
       - autoheal=true
 

--- a/services-available/heimdall.yml
+++ b/services-available/heimdall.yml
@@ -23,4 +23,5 @@ services:
       - traefik.http.routers.heimdall.rule=Host(`${HEIMDALL_CONTAINER_NAME:-heimdall}.${HOST_DOMAIN}`)
       - traefik.http.routers.heimdall.tls=true
       - traefik.http.routers.heimdall.service=heimdall
+      - traefik.http.routers.heimdall.middlewares=${HEIMDALL_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.heimdall.loadbalancer.server.port=80

--- a/services-available/homarr.yml
+++ b/services-available/homarr.yml
@@ -35,6 +35,7 @@ services:
       - traefik.enable=true
       - traefik.http.routers.homarr.entrypoints=websecure
       - traefik.http.routers.homarr.rule=Host(`${HOMARR_CONTAINER_NAME:-homarr}.${HOST_DOMAIN}`)
+      - traefik.http.routers.homarr.middlewares=${HOMARR_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.homarr.loadbalancer.server.port=7575
       - com.centurylinklabs.watchtower.enable=${HOMARR_WATCHTOWER_ENABLED:-true}
       - autoheal=true

--- a/services-available/homebox.yml
+++ b/services-available/homebox.yml
@@ -30,6 +30,7 @@ services:
       - traefik.enable=true
       - traefik.http.routers.homebox.entrypoints=websecure
       - traefik.http.routers.homebox.rule=Host(`${HOMEBOX_CONTAINER_NAME:-homebox}.${HOST_DOMAIN}`)
+      - traefik.http.routers.homebox.middlewares=${HOMEBOX_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.homebox.loadbalancer.server.port=7745
       - com.centurylinklabs.watchtower.enable=${HOMEBOX_WATCHTOWER_ENABLED:-true}
       - autoheal=true

--- a/services-available/homepage.yml
+++ b/services-available/homepage.yml
@@ -32,6 +32,7 @@ services:
       - traefik.enable=${HOMEPAGE_TRAEFIK_ENABLE:-true}
       - traefik.http.routers.homepage.entrypoints=websecure
       - traefik.http.routers.homepage.rule=Host(`${HOMEPAGE_CONTAINER_NAME:-homepage}.${HOST_DOMAIN}`)
+      - traefik.http.routers.homepage.middlewares=${HOMEPAGE_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.homepage.loadbalancer.server.port=3000
       - com.centurylinklabs.watchtower.enable=${HOMEPAGE_WATCHTOWER:-true}
       - autoheal=${HOMEPAGE_AUTOHEAL:-true}

--- a/services-available/homer.yml
+++ b/services-available/homer.yml
@@ -27,6 +27,7 @@ services:
       - traefik.enable=true
       - traefik.http.routers.homer.entrypoints=websecure
       - traefik.http.routers.homer.rule=Host(`${HOMER_CONTAINER_NAME:-homer}.${HOST_DOMAIN}`)
+      - traefik.http.routers.homer.middlewares=${HOMER_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.homer.loadbalancer.server.port=8080
       - com.centurylinklabs.watchtower.enable=${HOMER_WATCHTOWER_ENABLED:-true}
       - autoheal=true

--- a/services-available/huginn.yml
+++ b/services-available/huginn.yml
@@ -30,6 +30,7 @@ services:
       - traefik.enable=${HUGINN_TRAEFIK_ENABLED:-true}
       - traefik.http.routers.huginn.entrypoints=websecure
       - traefik.http.routers.huginn.rule=Host(`${HUGINN_CONTAINER_NAME:-huginn}.${HOST_DOMAIN}`)
+      - traefik.http.routers.huginn.middlewares=${HUGINN_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.huginn.loadbalancer.server.port=3000
       - com.centurylinklabs.watchtower.enable=${HUGINN_WATCHTOWER_ENABLED:-true}
       - autoheal=${HUGINN_AUTOHEAL_ENABLED:-true}

--- a/services-available/hypermind.yml
+++ b/services-available/hypermind.yml
@@ -21,6 +21,7 @@ services:
       - traefik.enable=${HYPERMIND_TRAEFIK_ENABLED:-true}
       - traefik.http.routers.hypermind.entrypoints=websecure
       - traefik.http.routers.hypermind.rule=Host(`${HYPERMIND_CONTAINER_NAME:-hypermind}.${HOST_DOMAIN}`)
+      - traefik.http.routers.hypermind.middlewares=${HYPERMIND_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.hypermind.loadbalancer.server.port=${HYPERMIND_PORT:-3000}
       - com.centurylinklabs.watchtower.enable=${HYPERMIND_WATCHTOWER_ENABLED:-true}
       - autoheal=${HYPERMIND_AUTOHEAL_ENABLED:-true}

--- a/services-available/immich.yml
+++ b/services-available/immich.yml
@@ -40,6 +40,7 @@ services:
       - traefik.docker.network=traefik
       - traefik.http.routers.immich.entrypoints=websecure
       - traefik.http.routers.immich.rule=Host(`${IMMICH_CONTAINER_NAME:-immich}.${HOST_DOMAIN}`)
+      - traefik.http.routers.immich.middlewares=${IMMICH_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.immich.loadbalancer.server.port=2283
       - com.centurylinklabs.watchtower.enable=${IMMICH_WATCHTOWER_ENABLED:-false}
       - autoheal=true

--- a/services-available/infinity.yml
+++ b/services-available/infinity.yml
@@ -46,6 +46,7 @@ services:
       - traefik.enable=${INFINITY_TRAEFIK_ENABLE:-true}
       - traefik.http.routers.infinity.entrypoints=websecure
       - traefik.http.routers.infinity.rule=Host(`${INFINITY_CONTAINER_NAME:-infinity}.${HOST_DOMAIN}`)
+      - traefik.http.routers.infinity.middlewares=${INFINITY_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.infinity.loadbalancer.server.port=7997
       - com.centurylinklabs.watchtower.enable=${INFINITY_WATCHTOWER_ENABLE:-true}
       - autoheal=${INFINITY_AUTOHEAL:-true}

--- a/services-available/influxdb.yml
+++ b/services-available/influxdb.yml
@@ -34,6 +34,7 @@ services:
       - traefik.enable=true
       - traefik.http.routers.influxdb.entrypoints=websecure
       - traefik.http.routers.influxdb.rule=Host(`${INFLUXDB_CONTAINER_NAME:-influxdb}.${HOST_DOMAIN}`)
+      - traefik.http.routers.influxdb.middlewares=${INFLUXDB_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.influxdb.loadbalancer.server.port=8086
       - com.centurylinklabs.watchtower.enable=${INFLUXDB_WATCHTOWER_ENABLED:-true}
       - autoheal=true

--- a/services-available/itflow.yml
+++ b/services-available/itflow.yml
@@ -61,6 +61,7 @@ services:
       - traefik.enable=true
       - traefik.http.routers.itflow.entrypoints=websecure
       - traefik.http.routers.itflow.rule=Host(`${ITFLOW_CONTAINER_NAME:-itflow}.${HOST_DOMAIN}`)
+      - traefik.http.routers.itflow.middlewares=${ITFLOW_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.itflow.loadbalancer.server.port=8080
       - com.centurylinklabs.watchtower.enable=${ITFLOW_WATCHTOWER_ENABLED:-true}
       - autoheal=true

--- a/services-available/ittools.yml
+++ b/services-available/ittools.yml
@@ -27,6 +27,7 @@ services:
       - traefik.enable=${ITTOOLS_TRAEFIK_ENABLED:-true}
       - traefik.http.routers.ittools.entrypoints=websecure
       - traefik.http.routers.ittools.rule=Host(`${ITTOOLS_HOST_NAME:-ittools}.${HOST_DOMAIN}`)
+      - traefik.http.routers.ittools.middlewares=${ITTOOLS_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       #- traefik.http.services.ittools.loadbalancer.server.scheme=https # enable if the service wants to connect over https
       - traefik.http.services.ittools.loadbalancer.server.port=80
       - com.centurylinklabs.watchtower.enable=${ITTOOLS_WATCHTOWER_ENABLED:-true}

--- a/services-available/iventoy.yml
+++ b/services-available/iventoy.yml
@@ -34,6 +34,7 @@ services:
       - traefik.enable=${IVENTOY_TRAEFIK_ENABLED:-true}
       - traefik.http.routers.iventoy.entrypoints=websecure
       - traefik.http.routers.iventoy.rule=Host(`${IVENTOY_CONTAINER_NAME:-iventoy}.${HOST_DOMAIN}`)
+      - traefik.http.routers.iventoy.middlewares=${IVENTOY_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.iventoy.loadbalancer.server.port=26000
       - com.centurylinklabs.watchtower.enable=${IVENTOY_WATCHTOWER_ENABLED:-true}
       - autoheal=${IVENTOY_AUTOHEAL_ENABLED:-true}

--- a/services-available/jellyfin.yml
+++ b/services-available/jellyfin.yml
@@ -28,17 +28,12 @@ services:
       # - 8920:8920 # https web gui
       - 7359:7359/udp # Jellyfin client discovery
       # - 1900:1900/udp # DNLA discovery uncomment if required
-    healthcheck:
-      test: curl --fail http://localhost:8096/health || exit 1
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 30s
     labels:
       - joyride.host.name=${JELLYFIN_CONTAINER_NAME:-jellyfin}.${HOST_DOMAIN}
       - traefik.enable=true
       - traefik.http.routers.jellyfin.entrypoints=websecure
       - traefik.http.routers.jellyfin.rule=Host(`${JELLYFIN_CONTAINER_NAME:-jellyfin}.${HOST_DOMAIN}`)
+      - traefik.http.routers.jellyfin.middlewares=${JELLYFIN_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.jellyfin.loadbalancer.server.port=8096
       - com.centurylinklabs.watchtower.enable=${JELLYFIN_WATCHTOWER_ENABLED:-true}
       - autoheal=true

--- a/services-available/jellyseerr.yml
+++ b/services-available/jellyseerr.yml
@@ -36,6 +36,7 @@ services:
       - traefik.enable=true
       - traefik.http.routers.jellyseerr.entrypoints=websecure
       - traefik.http.routers.jellyseerr.rule=Host(`${JELLYSEERR_CONTAINER_NAME:-jellyseerr}.${HOST_DOMAIN}`)
+      - traefik.http.routers.jellyseerr.middlewares=${JELLYSEERR_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       #- traefik.http.services.jellyseerr.loadbalancer.server.scheme=https # enable if the service wants to connect over>
       - traefik.http.services.jellyseerr.loadbalancer.server.port=5055
       - com.centurylinklabs.watchtower.enable=${JELLYSEERR_WATCHTOWER_ENABLED:-true}

--- a/services-available/joplin.yml
+++ b/services-available/joplin.yml
@@ -60,6 +60,7 @@ services:
       - traefik.enable=true
       - traefik.http.routers.joplin.entrypoints=websecure
       - traefik.http.routers.joplin.rule=Host(`${JOPLIN_CONTAINER_NAME:-joplin}.${HOST_DOMAIN}`)
+      - traefik.http.routers.joplin.middlewares=${JOPLIN_DB_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       #- traefik.http.services.joplin.loadbalancer.server.scheme=https # enable if the service wants to connect over https
       - traefik.http.services.joplin.loadbalancer.server.port=22300
       - com.centurylinklabs.watchtower.enable=${JOPLIN_WATCHTOWER_ENABLED:-true}

--- a/services-available/kaizoku.yml
+++ b/services-available/kaizoku.yml
@@ -40,7 +40,7 @@ services:
       - traefik.enable=true
       - traefik.http.routers.kaizoku.entrypoints=websecure
       - traefik.http.routers.kaizoku.rule=Host(`${KAIZOKU_CONTAINER_NAME:-kaizoku}.${HOST_DOMAIN}`)
-      - traefik.http.routers.kaizoku.middlewares=default-headers@file
+      - traefik.http.routers.kaizoku.middlewares=${KAIZOKU_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.kaizoku.loadbalancer.server.port=3000
       - com.centurylinklabs.watchtower.enable=${KAIZOKU_WATCHTOWER_ENABLED:-true}
       - autoheal=true

--- a/services-available/kaneo.yml
+++ b/services-available/kaneo.yml
@@ -45,6 +45,7 @@ services:
       - traefik.enable=${KANEO_TRAEFIK_ENABLED:-true}
       - traefik.http.routers.kaneo-api.entrypoints=websecure
       - traefik.http.routers.kaneo-api.rule=Host(`${KANEO_API_HOST_NAME:-kaneo-api}.${HOST_DOMAIN}`)
+      - traefik.http.routers.kaneo-api.middlewares=${KANEO_POSTGRES_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       # Uncomment the following line if the service wants to connect over HTTPS
       # - traefik.http.services.kaneo.loadbalancer.server.scheme=https
       - traefik.http.services.kaneo-api.loadbalancer.server.port=1337
@@ -70,6 +71,7 @@ services:
       - traefik.enable=${KANEO_TRAEFIK_ENABLED:-true}
       - traefik.http.routers.kaneo.entrypoints=websecure
       - traefik.http.routers.kaneo.rule=Host(`${KANEO_HOST_NAME:-kaneo}.${HOST_DOMAIN}`)
+      - traefik.http.routers.kaneo.middlewares=${KANEO_POSTGRES_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       # Uncomment the following line if the service wants to connect over HTTPS
       # - traefik.http.services.kaneo.loadbalancer.server.scheme=https
       - traefik.http.services.kaneo.loadbalancer.server.port=5173

--- a/services-available/kapowarr.yml
+++ b/services-available/kapowarr.yml
@@ -37,6 +37,7 @@ services:
       - traefik.enable=${KAPOWARR_TRAEFIK_ENABLE:-true}
       - traefik.http.routers.kapowarr.entrypoints=websecure
       - traefik.http.routers.kapowarr.rule=Host(`${KAPOWARR_CONTAINER_NAME:-kapowarr}.${HOST_DOMAIN}`)
+      - traefik.http.routers.kapowarr.middlewares=${KAPOWARR_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.kapowarr.loadbalancer.server.port=5656
       - com.centurylinklabs.watchtower.enable=${KAPOWARR_WATCHTOWER_ENABLE:-true}
       - autoheal=${KAPOWARR_AUTOHEAL:-true}

--- a/services-available/karakeep.yml
+++ b/services-available/karakeep.yml
@@ -59,6 +59,7 @@ services:
       - traefik.enable=${KARAKEEP_TRAEFIK_ENABLED:-true}
       - traefik.http.routers.karakeep.entrypoints=websecure
       - traefik.http.routers.karakeep.rule=Host(`${KARAKEEP_HOST_NAME:-karakeep}.${HOST_DOMAIN}`)
+      - traefik.http.routers.karakeep.middlewares=${KARAKEEP_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.karakeep.loadbalancer.server.port=3000
       - com.centurylinklabs.watchtower.enable=${KARAKEEP_WATCHTOWER_ENABLED:-true}
       - autoheal=${KARAKEEP_AUTOHEAL_ENABLED:-true}

--- a/services-available/kasm.yml
+++ b/services-available/kasm.yml
@@ -29,6 +29,7 @@ services:
       - traefik.enable=true
       - traefik.http.routers.kasm.entrypoints=websecure
       - traefik.http.routers.kasm.rule=Host(`${KASM_CONTAINER_NAME:-kasm}.${HOST_DOMAIN}`)
+      - traefik.http.routers.kasm.middlewares=${KASM_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.kasm.loadbalancer.server.scheme=https
       - traefik.http.services.kasm.loadbalancer.server.port=443
       - com.centurylinklabs.watchtower.enable=${KASM_WATCHTOWER_ENABLED:-true}

--- a/services-available/kestra.yml
+++ b/services-available/kestra.yml
@@ -32,6 +32,7 @@ services:
       - traefik.enable=true
       - traefik.http.routers.kestra.entrypoints=websecure
       - traefik.http.routers.kestra.rule=Host(`${KESTRA_CONTAINER_NAME:-kestra}.${HOST_DOMAIN}`)
+      - traefik.http.routers.kestra.middlewares=${KESTRA_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.kestra.loadbalancer.server.port=8080
       - com.centurylinklabs.watchtower.enable=${KESTRA_WATCHTOWER_ENABLED:-true}
       - autoheal=true

--- a/services-available/kimai.yml
+++ b/services-available/kimai.yml
@@ -29,6 +29,7 @@ services:
       - traefik.enable=true
       - traefik.http.routers.kimai.entrypoints=websecure
       - traefik.http.routers.kimai.rule=Host(`${KIMAI_CONTAINER_NAME:-kimai}.${HOST_DOMAIN}`)
+      - traefik.http.routers.kimai.middlewares=${KIMAI_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.kimai.loadbalancer.server.port=8001
       - com.centurylinklabs.watchtower.enable=${KIMAI_WATCHTOWER_ENABLED:-true}
       - autoheal=true

--- a/services-available/kitchenowl.yml
+++ b/services-available/kitchenowl.yml
@@ -40,6 +40,7 @@ services:
       - traefik.enable=${KITCHENOWL_TRAEFIK_ENABLED:-true}
       - traefik.http.routers.kitchenowl.entrypoints=websecure
       - traefik.http.routers.kitchenowl.rule=Host(`${KITCHENOWL_CONTAINER_NAME:-kitchenowl}.${HOST_DOMAIN}`)
+      - traefik.http.routers.kitchenowl.middlewares=${KITCHENOWL_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.kitchenowl.loadbalancer.server.port=80
       - com.centurylinklabs.watchtower.enable=${KITCHENOWL_WATCHTOWER_ENABLED:-true}
       - autoheal=${KITCHENOWL_AUTOHEAL_ENABLED:-true}  

--- a/services-available/komga.yml
+++ b/services-available/komga.yml
@@ -28,6 +28,7 @@ services:
       - traefik.enable=true
       - traefik.http.routers.komga.entrypoints=websecure
       - traefik.http.routers.komga.rule=Host(`${KOMGA_CONTAINER_NAME:-komga}.${HOST_DOMAIN}`)
+      - traefik.http.routers.komga.middlewares=${KOMGA_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.komga.loadbalancer.server.port=25600
       - com.centurylinklabs.watchtower.enable=${KOMGA_WATCHTOWER_ENABLED:-true}
       - autoheal=true

--- a/services-available/komodo.yml
+++ b/services-available/komodo.yml
@@ -74,6 +74,7 @@ services:
       - traefik.docker.network=traefik
       - traefik.http.routers.komodo.entrypoints=websecure
       - traefik.http.routers.komodo.rule=Host(`${KOMODO_CORE_CONTAINER_NAME:-komodo}.${HOST_DOMAIN}`)
+      - traefik.http.routers.komodo.middlewares=${KOMODO_DB_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.komodo.loadbalancer.server.port=9120
       - com.centurylinklabs.watchtower.enable=${KOMODO_WATCHTOWER_ENABLED:-false}
       - komodo.skip=true  

--- a/services-available/lazylibrarian.yml
+++ b/services-available/lazylibrarian.yml
@@ -37,6 +37,7 @@ services:
       - traefik.enable=${LAZYLIBRARIAN_TRAEFIK_ENABLED:-true}
       - traefik.http.routers.lazylibrarian.entrypoints=websecure
       - traefik.http.routers.lazylibrarian.rule=Host(`${LAZYLIBRARIAN_HOST_NAME:-lazylibrarian}.${HOST_DOMAIN}`)
+      - traefik.http.routers.lazylibrarian.middlewares=${LAZYLIBRARIAN_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       #- traefik.http.services.lazylibrarian.loadbalancer.server.scheme=https # enable if the service wants to connect over https
       - traefik.http.services.lazylibrarian.loadbalancer.server.port=5299
       - com.centurylinklabs.watchtower.enable=${LAZYLIBRARIAN_WATCHTOWER_ENABLED:-true}

--- a/services-available/librespeed.yml
+++ b/services-available/librespeed.yml
@@ -28,6 +28,7 @@ services:
       - traefik.enable=true
       - traefik.http.routers.librespeed.entrypoints=websecure
       - traefik.http.routers.librespeed.rule=Host(`librespeed.${HOST_DOMAIN}`)
+      - traefik.http.routers.librespeed.middlewares=${LIBRESPEED_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.librespeed.loadbalancer.server.port=80
       - com.centurylinklabs.watchtower.enable=${LIBRESPEED_WATCHTOWER_ENABLED:-true}
       - autoheal=true

--- a/services-available/lidarr.yml
+++ b/services-available/lidarr.yml
@@ -40,6 +40,7 @@ services:
       - traefik.enable=true
       - traefik.http.routers.lidarr.entrypoints=websecure
       - traefik.http.routers.lidarr.rule=Host(`lidarr.${HOST_DOMAIN}`)
+      - traefik.http.routers.lidarr.middlewares=${LIDARR_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.lidarr.loadbalancer.server.port=8686
       - com.centurylinklabs.watchtower.enable=${LIDARR_WATCHTOWER_ENABLED:-true}
       - autoheal=true

--- a/services-available/lidify.yml
+++ b/services-available/lidify.yml
@@ -30,6 +30,7 @@ services:
       - traefik.enable=${LIDIFY_TRAEFIK_ENABLED:-true}
       - traefik.http.routers.lidify.entrypoints=websecure
       - traefik.http.routers.lidify.rule=Host(`${LIDIFY_HOST_NAME:-lidify}.${HOST_DOMAIN}`)
+      - traefik.http.routers.lidify.middlewares=${LIDIFY_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       #- traefik.http.services.lidify.loadbalancer.server.scheme=https # enable if the service wants to connect over https
       - traefik.http.services.lidify.loadbalancer.server.port=5000
       - com.centurylinklabs.watchtower.enable=${LIDIFY_WATCHTOWER_ENABLED:-true}

--- a/services-available/linkding.yml
+++ b/services-available/linkding.yml
@@ -33,6 +33,7 @@ services:
       - traefik.enable=true
       - traefik.http.routers.linkding.entrypoints=websecure
       - traefik.http.routers.linkding.rule=Host(`${LINKDING_CONTAINER_NAME:-linkding}.${HOST_DOMAIN}`)
+      - traefik.http.routers.linkding.middlewares=${LINKDING_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       #- traefik.http.services.linkding.loadbalancer.server.scheme=https # enable if the service wants to connect over https
       - traefik.http.services.linkding.loadbalancer.server.port=9090
       - com.centurylinklabs.watchtower.enable=${LINKDING_WATCHTOWER_ENABLED:-true}

--- a/services-available/lubelog.yml
+++ b/services-available/lubelog.yml
@@ -47,6 +47,7 @@ services:
       - traefik.enable=${LUBELOG_TRAEFIK_ENABLED:-true}
       - traefik.http.routers.lubelog.entrypoints=websecure
       - traefik.http.routers.lubelog.rule=Host(`${LUBELOG_CONTAINER_NAME:-lubelog}.${HOST_DOMAIN}`)
+      - traefik.http.routers.lubelog.middlewares=${LUBELOG_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       #- traefik.http.services.lubelog.loadbalancer.server.scheme=https # enable if the service wants to connect over https
       - traefik.http.services.lubelog.loadbalancer.server.port=8080
       - com.centurylinklabs.watchtower.enable=${LUBELOG_WATCHTOWER_ENABLED:-true}

--- a/services-available/lychee.yml
+++ b/services-available/lychee.yml
@@ -26,6 +26,7 @@ services:
       - traefik.enable=true
       - traefik.http.routers.lychee.entrypoints=websecure
       - traefik.http.routers.lychee.rule=Host(`lychee.${HOST_DOMAIN}`)
+      - traefik.http.routers.lychee.middlewares=${LYCHEE_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.lychee.loadbalancer.server.port=80
       - com.centurylinklabs.watchtower.enable=${LYCHEE_WATCHTOWER_ENABLED:-true}
       - autoheal=true

--- a/services-available/mailhog.yml
+++ b/services-available/mailhog.yml
@@ -33,6 +33,7 @@ services:
       - traefik.enable=true
       - traefik.http.routers.mailhog.entrypoints=websecure
       - traefik.http.routers.mailhog.rule=Host(`${MAILHOG_CONTAINER_NAME:-mailhog}.${HOST_DOMAIN}`)
+      - traefik.http.routers.mailhog.middlewares=${MAILHOG_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.mailhog.loadbalancer.server.port=8025
       - com.centurylinklabs.watchtower.enable=${MAILHOG_WATCHTOWER_ENABLED:-true}
       - autoheal=true

--- a/services-available/maintainerr.yml
+++ b/services-available/maintainerr.yml
@@ -26,6 +26,7 @@ services:
       - traefik.enable=${MAINTAINERR_TRAEFIK_ENABLED:-true}
       - traefik.http.routers.maintainerr.entrypoints=websecure
       - traefik.http.routers.maintainerr.rule=Host(`${MAINTAINERR_CONTAINER_NAME:-maintainerr}.${HOST_DOMAIN}`)
+      - traefik.http.routers.maintainerr.middlewares=${MAINTAINERR_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       #- traefik.http.services.maintainerr.loadbalancer.server.scheme=https # enable if the service wants to connect over https
       - traefik.http.services.maintainerr.loadbalancer.server.port=6246
       - com.centurylinklabs.watchtower.enable=${MAINTAINERR_WATCHTOWER_ENABLED:-true}

--- a/services-available/makemkv.yml
+++ b/services-available/makemkv.yml
@@ -33,6 +33,7 @@ services:
       - traefik.enable=true
       - traefik.http.routers.makemkv.entrypoints=websecure
       - traefik.http.routers.makemkv.rule=Host(`${MAKEMKV_CONTAINER_NAME:-makemkv}.${HOST_DOMAIN}`)
+      - traefik.http.routers.makemkv.middlewares=${MAKEMKV_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.makemkv.loadbalancer.server.port=5800
       - com.centurylinklabs.watchtower.enable=${MAKEMKV_WATCHTOWER_ENABLED:-true}
       - autoheal=true

--- a/services-available/manyfold.yml
+++ b/services-available/manyfold.yml
@@ -37,6 +37,7 @@ services:
       - traefik.enable=${MANYFOLD_TRAEFIK_ENABLED:-true}
       - traefik.http.routers.manyfold.entrypoints=websecure
       - traefik.http.routers.manyfold.rule=Host(`${MANYFOLD_HOST_NAME:-manyfold}.${HOST_DOMAIN}`)
+      - traefik.http.routers.manyfold.middlewares=${MANYFOLD_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       #- traefik.http.services.manyfold.loadbalancer.server.scheme=https # enable if the service wants to connect over https
       - traefik.http.services.manyfold.loadbalancer.server.port=3214
       - com.centurylinklabs.watchtower.enable=${MANYFOLD_WATCHTOWER_ENABLED:-true}

--- a/services-available/mazanoke.yml
+++ b/services-available/mazanoke.yml
@@ -25,6 +25,7 @@ services:
       - traefik.enable=${MAZANOKE_TRAEFIK_ENABLED:-true}
       - traefik.http.routers.mazanoke.entrypoints=websecure
       - traefik.http.routers.mazanoke.rule=Host(`${MAZANOKE_HOST_NAME:-mazanoke}.${HOST_DOMAIN}`)
+      - traefik.http.routers.mazanoke.middlewares=${MAZANOKE_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.mazanoke.loadbalancer.server.port=80
       - com.centurylinklabs.watchtower.enable=${MAZANOKE_WATCHTOWER_ENABLED:-true}
       - autoheal=${MAZANOKE_AUTOHEAL_ENABLED:-true}

--- a/services-available/mealie.yml
+++ b/services-available/mealie.yml
@@ -45,6 +45,7 @@ services:
       - traefik.enable=true
       - traefik.http.routers.mealie.entrypoints=websecure
       - traefik.http.routers.mealie.rule=Host(`${MEALIE_CONTAINER_NAME:-mealie}.${HOST_DOMAIN}`)
+      - traefik.http.routers.mealie.middlewares=${MEALIE_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.mealie.loadbalancer.server.port=9000
       - com.centurylinklabs.watchtower.enable=${MEALIE_WATCHTOWER_ENABLED:-true}
       - autoheal=true

--- a/services-available/mediamanager.yml
+++ b/services-available/mediamanager.yml
@@ -106,6 +106,7 @@ services:
       - traefik.enable=${MEDIAMANAGER_TRAEFIK_ENABLED:-true}
       - traefik.http.routers.mediamanager.entrypoints=websecure
       - traefik.http.routers.mediamanager.rule=Host(`${MEDIAMANAGER_HOST_NAME:-mediamanager}.${HOST_DOMAIN}`)
+      - traefik.http.routers.mediamanager.middlewares=${MEDIAMANAGERBACKEND_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       #- traefik.http.services.mediamanager.loadbalancer.server.scheme=https # enable if the service wants to connect over https
       - traefik.http.services.mediamanager.loadbalancer.server.port=3000
       - com.centurylinklabs.watchtower.enable=${MEDIAMANAGER_WATCHTOWER_ENABLED:-true}

--- a/services-available/minio.yml
+++ b/services-available/minio.yml
@@ -71,7 +71,7 @@ services:
       # - HTTPS-related settings:
       - traefik.http.routers.minio-https.entrypoints=websecure
       - traefik.http.routers.minio-https.tls=true
-      - traefik.http.routers.minio-https.middlewares=gzip-compress@docker
+      - traefik.http.routers.minio-https.middlewares=${MINIO_MIDDLEWARES:-default-headers@file,gzip-compress@docker,noindex-headers@file}
       - traefik.http.routers.minio-https.rule=Host(`${MINIO_API_HOST}.${HOST_DOMAIN}`)
       - traefik.http.routers.minio-https.service=minio-backend
       
@@ -89,7 +89,7 @@ services:
       # - HTTPS-related settings:
       - traefik.http.routers.minio-admin-https.entrypoints=websecure
       - traefik.http.routers.minio-admin-https.tls=true
-      - traefik.http.routers.minio-admin-https.middlewares=gzip-compress@docker
+      - traefik.http.routers.minio-admin-https.middlewares=${MINIO_MIDDLEWARES:-default-headers@file,gzip-compress@docker,noindex-headers@file}
       - traefik.http.routers.minio-admin-https.rule=Host(`${MINIO_DASHBOARD_HOST}.${HOST_DOMAIN}`)
       - traefik.http.routers.minio-admin-https.service=minio-admin-backend
       

--- a/services-available/n8n.yml
+++ b/services-available/n8n.yml
@@ -65,6 +65,7 @@ services:
       - traefik.enable=${N8N_TRAEFIK_ENABLED:-true}
       - traefik.http.routers.n8n.entrypoints=websecure
       - traefik.http.routers.n8n.rule=Host(`${N8N_HOST_NAME:-n8n}.${HOST_DOMAIN}`)
+      - traefik.http.routers.n8n.middlewares=${N8N_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       # - traefik.http.services.n8n.loadbalancer.server.scheme=https # enable if the service wants to connect over https
       - traefik.http.services.n8n.loadbalancer.server.port=${N8N_PORT:-5678}
       - com.centurylinklabs.watchtower.enable=${N8N_WATCHTOWER_ENABLED:-true}

--- a/services-available/navidrome.yml
+++ b/services-available/navidrome.yml
@@ -30,6 +30,7 @@ services:
       - traefik.enable=true
       - traefik.http.routers.navidrome.entrypoints=websecure
       - traefik.http.routers.navidrome.rule=Host(`${NAVIDROME_CONTAINER_NAME:-navidrome}.${HOST_DOMAIN}`)
+      - traefik.http.routers.navidrome.middlewares=${NAVIDROME_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.navidrome.loadbalancer.server.port=4533
       - com.centurylinklabs.watchtower.enable=${NAVIDROME_WATCHTOWER_ENABLED:-true}
       - autoheal=true

--- a/services-available/netbootxyz.yml
+++ b/services-available/netbootxyz.yml
@@ -33,6 +33,7 @@ services:
       - traefik.enable=true
       - traefik.http.routers.netbootxyz.entrypoints=websecure
       - traefik.http.routers.netbootxyz.rule=Host(`${NETBOOTXYZ_CONTAINER_NAME:-netbootxyz}.${HOST_DOMAIN}`)
+      - traefik.http.routers.netbootxyz.middlewares=${NETBOOTXYZ_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.netbootxyz.loadbalancer.server.port=3000
       - com.centurylinklabs.watchtower.enable=${NETBOOTXYZ_WATCHTOWER_ENABLED:-true}
       - autoheal=true

--- a/services-available/netbox.yml
+++ b/services-available/netbox.yml
@@ -50,6 +50,7 @@ services:
       - traefik.http.routers.netbox.rule=Host(`${NETBOX_CONTAINER_NAME:-netbox}.${HOST_DOMAIN}`)
       - traefik.http.services.netbox.loadbalancer.server.scheme=http # enable if the service wants to connect over https
       - traefik.http.routers.netbox.service=netbox
+      - traefik.http.routers.netbox.middlewares=${NETBOX_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.netbox.loadbalancer.server.port=8000
       - com.centurylinklabs.watchtower.enable=${NETBOX_WATCHTOWER_ENABLED:-true}
       - autoheal=true

--- a/services-available/newsdash.yml
+++ b/services-available/newsdash.yml
@@ -28,6 +28,7 @@ services:
       - traefik.enable=true
       - traefik.http.routers.newsdash.entrypoints=websecure
       - traefik.http.routers.newsdash.rule=Host(`newsdash.${HOST_DOMAIN}`)
+      - traefik.http.routers.newsdash.middlewares=${NEWSDASH_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.newsdash.loadbalancer.server.port=3001
       - com.centurylinklabs.watchtower.enable=${NEWSDASH_WATCHTOWER_ENABLED:-true}
       - autoheal=true

--- a/services-available/nextcloud.yml
+++ b/services-available/nextcloud.yml
@@ -35,6 +35,7 @@ services:
       - traefik.http.routers.nextcloud.rule=Host(`${NEXTCLOUD_CONTAINER_NAME:-nextcloud}.${HOST_DOMAIN}`)
       - traefik.http.routers.nextcloud.tls=true
       - traefik.http.routers.nextcloud.service=nextcloud
+      - traefik.http.routers.nextcloud.middlewares=${NEXTCLOUD_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.nextcloud.loadbalancer.server.scheme=https
       - traefik.http.services.nextcloud.loadbalancer.server.port=443
       - com.centurylinklabs.watchtower.enable=${NEXTCLOUD_WATCHTOWER_ENABLED:-true}

--- a/services-available/nginx.yml
+++ b/services-available/nginx.yml
@@ -23,6 +23,7 @@ services:
       - traefik.enable=${NGINX_TRAEFIK_ENABLED:-true}
       - traefik.http.routers.nginx.entrypoints=websecure
       - traefik.http.routers.nginx.rule=Host(`${NGINX_HOST_NAME:-nginx}.${HOST_DOMAIN}`)
+      - traefik.http.routers.nginx.middlewares=${NGINX_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.nginx.loadbalancer.server.port=80
       - com.centurylinklabs.watchtower.enable=${NGINX_WATCHTOWER_ENABLED:-true}
       - autoheal=${NGINX_AUTOHEAL_ENABLED:-true}

--- a/services-available/nightscout.yml
+++ b/services-available/nightscout.yml
@@ -44,6 +44,7 @@ services:
       - traefik.docker.network=traefik
       - traefik.http.routers.nightscout.entrypoints=websecure
       - traefik.http.routers.nightscout.rule=Host(`${NIGHTSCOUNT_CONTAINER_NAME:-nightscout}.${HOST_DOMAIN}`)
+      - traefik.http.routers.nightscout.middlewares=${NSMONGO_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.nightscout.loadbalancer.server.port=1337
       - com.centurylinklabs.watchtower.enable=${NIGHTSCOUNT_WATCHTOWER_ENABLED:-false}
       - autoheal=true

--- a/services-available/nocodb.yml
+++ b/services-available/nocodb.yml
@@ -35,6 +35,7 @@ services:
       - traefik.enable=${NOCODB_TRAEFIK_ENABLED:-true}
       - traefik.http.routers.nocodb.entrypoints=websecure
       - traefik.http.routers.nocodb.rule=Host(`${NOCODB_HOST_NAME:-nocodb}.${HOST_DOMAIN}`)
+      - traefik.http.routers.nocodb.middlewares=${NOCODB_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       #- traefik.http.services.nocodb.loadbalancer.server.scheme=https # enable if the service wants to connect over https
       - traefik.http.services.nocodb.loadbalancer.server.port=8080
       - com.centurylinklabs.watchtower.enable=${NOCODB_WATCHTOWER_ENABLED:-true}

--- a/services-available/nodered.yml
+++ b/services-available/nodered.yml
@@ -29,6 +29,7 @@ services:
       - traefik.enable=true
       - traefik.http.routers.nodered.entrypoints=websecure
       - traefik.http.routers.nodered.rule=Host(`nodered.${HOST_DOMAIN}`)
+      - traefik.http.routers.nodered.middlewares=${NODERED_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.nodered.loadbalancer.server.port=1880
       - com.centurylinklabs.watchtower.enable=${NODERED_WATCHTOWER_ENABLED:-true}
       - autoheal=true

--- a/services-available/ntfy.yml
+++ b/services-available/ntfy.yml
@@ -57,6 +57,7 @@ services:
       - traefik.enable=${NTFY_TRAEFIK_ENABLED:-true}
       - traefik.http.routers.ntfy.entrypoints=websecure
       - traefik.http.routers.ntfy.rule=Host(`${NTFY_HOST_NAME:-ntfy}.${HOST_DOMAIN}`)
+      - traefik.http.routers.ntfy.middlewares=${NTFY_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.ntfy.loadbalancer.server.port=80
       - com.centurylinklabs.watchtower.enable=${NTFY_WATCHTOWER_ENABLED:-true}
       - autoheal=${NTFY_AUTOHEAL_ENABLED:-true}

--- a/services-available/nutify.yml
+++ b/services-available/nutify.yml
@@ -68,6 +68,7 @@ services:
       - traefik.enable=${NUTIFY_TRAEFIK_ENABLED:-true}
       - traefik.http.routers.nutify.entrypoints=websecure
       - traefik.http.routers.nutify.rule=Host(`${NUTIFY_HOST_NAME:-nutify}.${HOST_DOMAIN}`)
+      - traefik.http.routers.nutify.middlewares=${NUTIFY_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       #- traefik.http.services.nutify.loadbalancer.server.scheme=https # enable if the service wants to connect over https
       - traefik.http.services.nutify.loadbalancer.server.port=5050
       - com.centurylinklabs.watchtower.enable=${NUTIFY_WATCHTOWER_ENABLED:-true}

--- a/services-available/nzbget.yml
+++ b/services-available/nzbget.yml
@@ -33,6 +33,7 @@ services:
       - traefik.enable=true
       - traefik.http.routers.nzbget.entrypoints=websecure
       - traefik.http.routers.nzbget.rule=Host(`${NZBGET_CONTAINER_NAME:-nzbget}.${HOST_DOMAIN}`)
+      - traefik.http.routers.nzbget.middlewares=${NZBGET_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.nzbget.loadbalancer.server.port=6789
       - com.centurylinklabs.watchtower.enable=${NZBGET_WATCHTOWER_ENABLED:-true}
       - autoheal=true

--- a/services-available/obsidian.yml
+++ b/services-available/obsidian.yml
@@ -27,6 +27,7 @@ services:
       - traefik.enable=${OBSIDIAN_TRAEFIK_ENABLED:-true}
       - traefik.http.routers.obsidian.entrypoints=websecure
       - traefik.http.routers.obsidian.rule=Host(`${OBSIDIAN_HOST_NAME:-obsidian}.${HOST_DOMAIN}`)
+      - traefik.http.routers.obsidian.middlewares=${OBSIDIAN_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       #- traefik.http.services.obsidian.loadbalancer.server.scheme=https # enable if the service wants to connect over https
       - traefik.http.services.obsidian.loadbalancer.server.port=3000
       - com.centurylinklabs.watchtower.enable=${OBSIDIAN_WATCHTOWER_ENABLED:-true}

--- a/services-available/odoo.yml
+++ b/services-available/odoo.yml
@@ -37,6 +37,7 @@ services:
       - traefik.http.routers.odoo.rule=Host(`${ODOO_HOST_NAME:-odoo}.${HOST_DOMAIN}`)
       - traefik.http.routers.odoo.tls.certresolver=letsencrypt
       - traefik.http.routers.odoo.service=odoo
+      - traefik.http.routers.odoo.middlewares=${ODOO_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       #- traefik.http.services.odoo.loadbalancer.server.scheme=https # enable if the service wants to connect over https
       - traefik.http.services.odoo.loadbalancer.server.port=8069
 

--- a/services-available/olivetin.yml
+++ b/services-available/olivetin.yml
@@ -21,6 +21,7 @@ services:
       - traefik.enable=true
       - traefik.http.routers.olivetin.entrypoints=websecure
       - traefik.http.routers.olivetin.rule=Host(`${OLIVETIN_HOST_NAME:-olivetin}.${HOST_DOMAIN}`)
+      - traefik.http.routers.olivetin.middlewares=${OLIVETIN_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.olivetin.loadbalancer.server.port=1337
       - com.centurylinklabs.watchtower.enable=${OLIVETIN_WATCHTOWER_ENABLED:-true}
       - autoheal=true

--- a/services-available/ollama-webui.yml
+++ b/services-available/ollama-webui.yml
@@ -28,6 +28,7 @@ services:
       - traefik.enable=${OLLAMA_WEBUI_TRAEFIK_ENABLE:-true}
       - traefik.http.routers.ollama-webui.entrypoints=websecure
       - traefik.http.routers.ollama-webui.rule=Host(`${OLLAMA_WEBUI_CONTAINER_NAME:-chat}.${HOST_DOMAIN}`)
+      - traefik.http.routers.ollama-webui.middlewares=${OLLAMA_WEBUI_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.ollama-webui.loadbalancer.server.port=8080
       - com.centurylinklabs.watchtower.enable=${OLLAMA_WEBUI_WATCHTOWER_ENABLE:-true}
       - autoheal=${OLLAMA_WEBUI_AUTOHEAL:-true}

--- a/services-available/ollama.yml
+++ b/services-available/ollama.yml
@@ -36,6 +36,7 @@ services:
       - traefik.enable=${OLLAMA_TRAEFIK_ENABLE:-true}
       - traefik.http.routers.ollama.entrypoints=websecure
       - traefik.http.routers.ollama.rule=Host(`${OLLAMA_CONTAINER_NAME:-ollama}.${HOST_DOMAIN}`)
+      - traefik.http.routers.ollama.middlewares=${OLLAMA_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.ollama.loadbalancer.server.port=11434
       - com.centurylinklabs.watchtower.enable=${OLLAMA_WATCHTOWER_ENABLE:-true}
       - autoheal=${OLLAMA_AUTOHEAL:-true}

--- a/services-available/omada.yml
+++ b/services-available/omada.yml
@@ -58,6 +58,7 @@ services:
       - traefik.enable=true
       - traefik.http.routers.omada.entrypoints=websecure
       - traefik.http.routers.omada.rule=Host(`${OMADA_CONTAINER_NAME:-omada}.${HOST_DOMAIN}`)
+      - traefik.http.routers.omada.middlewares=${OMADA_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.omada.loadbalancer.server.scheme=https
       - traefik.http.services.omada.loadbalancer.server.port=8043
       - com.centurylinklabs.watchtower.enable=${OMADA_WATCHTOWER_ENABLED:-true}

--- a/services-available/onboard.yml
+++ b/services-available/onboard.yml
@@ -34,6 +34,7 @@ services:
       - traefik.enable=${ONBOARD_TRAEFIK_ENABLE:-true}
       - traefik.http.routers.onboard.entrypoints=websecure
       - traefik.http.routers.onboard.rule=Host(`${ONBOARD_CONTAINER_NAME:-onboard}.${HOST_DOMAIN}`)
+      - traefik.http.routers.onboard.middlewares=${ONBOARD_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.onboard.loadbalancer.server.port=9830
       - com.centurylinklabs.watchtower.enable=${ONBOARD_WATCHTOWER_ENABLE:-true}
       - autoheal=${ONBOARD_AUTOHEAL:-true}

--- a/services-available/ongoing.yml
+++ b/services-available/ongoing.yml
@@ -27,6 +27,7 @@ services:
       - traefik.enable=true
       - traefik.http.routers.ongoing.entrypoints=websecure
       - traefik.http.routers.ongoing.rule=Host(`${ONGOING_CONTAINER_NAME:-ongoing}.${HOST_DOMAIN}`)
+      - traefik.http.routers.ongoing.middlewares=${ONGOING_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.ongoing.loadbalancer.server.port=9380
       - com.centurylinklabs.watchtower.enable=${ONGOING_WATCHTOWER_ENABLED:-true}
       - autoheal=true

--- a/services-available/onramp-dashboard.yml
+++ b/services-available/onramp-dashboard.yml
@@ -40,6 +40,7 @@ services:
       - traefik.enable=${ONRAMP_DASHBOARD_TRAEFIK_ENABLE:-true}
       - traefik.http.routers.onramp-dashboard.entrypoints=websecure
       - traefik.http.routers.onramp-dashboard.rule=Host(`${ONRAMP_DASHBOARD_HOST_NAME:-dashboard}.${HOST_DOMAIN}`)
+      - traefik.http.routers.onramp-dashboard.middlewares=${ONRAMP_DASHBOARD_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.onramp-dashboard.loadbalancer.server.port=8000
       - com.centurylinklabs.watchtower.enable=${ONRAMP_DASHBOARD_WATCHTOWER:-true}
       - autoheal=${ONRAMP_DASHBOARD_AUTOHEAL:-true}

--- a/services-available/openspeedtest.yml
+++ b/services-available/openspeedtest.yml
@@ -27,6 +27,6 @@ services:
       - traefik.http.routers.openspeedtest.rule=Host(`${OPENSPEEDTEST_CONTAINER_NAME:-openspeedtest}.${HOST_DOMAIN}`)
       - traefik.http.services.openspeedtest.loadbalancer.server.port=3000
       - traefik.http.middlewares.limit.buffering.maxRequestBodyBytes=10000000000
-      - traefik.http.routers.openspeedtest.middlewares=limit
+      - traefik.http.routers.openspeedtest.middlewares=${OPENSPEEDTEST_MIDDLEWARES:-default-headers@file,limit,noindex-headers@file}
       - com.centurylinklabs.watchtower.enable=${OPENSPEEDTEST_WATCHTOWER_ENABLED:-true}
       - autoheal=true

--- a/services-available/overseerr.yml
+++ b/services-available/overseerr.yml
@@ -35,6 +35,7 @@ services:
       - traefik.enable=true
       - traefik.http.routers.overseerr.entrypoints=websecure
       - traefik.http.routers.overseerr.rule=Host(`${OVERSEERR_CONTAINER_NAME:-overseerr}.${HOST_DOMAIN}`)
+      - traefik.http.routers.overseerr.middlewares=${OVERSEERR_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.overseerr.loadbalancer.server.port=5055
       - com.centurylinklabs.watchtower.enable=${OVERSEERR_WATCHTOWER_ENABLED:-true}
       - autoheal=true

--- a/services-available/owncast.yml
+++ b/services-available/owncast.yml
@@ -28,6 +28,7 @@ services:
       - traefik.enable=true
       - traefik.http.routers.owncast.entrypoints=websecure
       - traefik.http.routers.owncast.rule=Host(`${OWNCAST_CONTAINER_NAME:-owncast}.${HOST_DOMAIN}`)
+      - traefik.http.routers.owncast.middlewares=${OWNCAST_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.owncast.loadbalancer.server.port=8080
       - com.centurylinklabs.watchtower.enable=${OWNCAST_WATCHTOWER_ENABLED:-true}
       - autoheal=true

--- a/services-available/paperless-ai.yml
+++ b/services-available/paperless-ai.yml
@@ -27,6 +27,7 @@ services:
       - traefik.enable=${PAPERLESS_AI_TRAEFIK_ENABLED:-true}
       - traefik.http.routers.paperless-ai.entrypoints=websecure
       - traefik.http.routers.paperless-ai.rule=Host(`${PAPERLESS_AI_HOST_NAME:-paperless-ai}.${HOST_DOMAIN}`)
+      - traefik.http.routers.paperless-ai.middlewares=${PAPERLESS_AI_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       #- traefik.http.services.paperless-ai.loadbalancer.server.scheme=https # enable if the service wants to connect over https
       - traefik.http.services.paperless-ai.loadbalancer.server.port=3000
       - com.centurylinklabs.watchtower.enable=${PAPERLESS_AI_WATCHTOWER_ENABLED:-true}

--- a/services-available/paperless-ngx-postgres.yml
+++ b/services-available/paperless-ngx-postgres.yml
@@ -103,6 +103,7 @@ services:
       - traefik.enable=true
       - traefik.http.routers.paperless-ngx-postgres.entrypoints=websecure
       - traefik.http.routers.paperless-ngx-postgres.rule=Host(`${PAPERLESS_NGX_CONTAINER_NAME:-paperless}.${HOST_DOMAIN}`)
+      - traefik.http.routers.paperless-ngx-postgres.middlewares=${PAPERLESS_DB_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.paperless-ngx-postgres.loadbalancer.server.port=8000
       - com.centurylinklabs.watchtower.enable=${PAPERLESS_NGX_WATCHTOWER_ENABLED:-true}
       - autoheal=true

--- a/services-available/paperless-ngx.yml
+++ b/services-available/paperless-ngx.yml
@@ -98,6 +98,7 @@ services:
       - traefik.enable=true
       - traefik.http.routers.paperless-ngx.entrypoints=websecure
       - traefik.http.routers.paperless-ngx.rule=Host(`${PAPERLESS_NGX_CONTAINER_NAME:-paperless-ngx}.${HOST_DOMAIN}`)
+      - traefik.http.routers.paperless-ngx.middlewares=${PAPERLESS_NGX_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.paperless-ngx.loadbalancer.server.port=8000
       - com.centurylinklabs.watchtower.enable=${PAPERLESS_NGX_WATCHTOWER_ENABLED:-true}
       - autoheal=true

--- a/services-available/pgadmin.yml
+++ b/services-available/pgadmin.yml
@@ -31,6 +31,7 @@ services:
       - traefik.enable=true
       - traefik.http.routers.pgadmin.entrypoints=websecure
       - traefik.http.routers.pgadmin.rule=Host(`pgadmin.${HOST_DOMAIN}`)
+      - traefik.http.routers.pgadmin.middlewares=${PGADMIN_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.pgadmin.loadbalancer.server.port=80
       - com.centurylinklabs.watchtower.enable=${PGADMIN_WATCHTOWER_ENABLED:-true}
       - autoheal=true

--- a/services-available/photoprism.yml
+++ b/services-available/photoprism.yml
@@ -37,6 +37,7 @@ services:
       - traefik.enable=true
       - traefik.http.routers.photoprism.entrypoints=websecure
       - traefik.http.routers.photoprism.rule=Host(`${PHOTOPRISM_CONTAINER_NAME:-photoprism}.${HOST_DOMAIN}`)
+      - traefik.http.routers.photoprism.middlewares=${PHOTOPRISM_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.photoprism.loadbalancer.server.port=2342
       - com.centurylinklabs.watchtower.enable=${PHOTOPRISM_WATCHTOWER_ENABLED:-true}
       - autoheal=true

--- a/services-available/phpmyadmin.yml
+++ b/services-available/phpmyadmin.yml
@@ -29,6 +29,7 @@ services:
       - traefik.enable=true
       - traefik.http.routers.phpmyadmin.entrypoints=websecure
       - traefik.http.routers.phpmyadmin.rule=Host(`phpmyadmin.${HOST_DOMAIN}`)
+      - traefik.http.routers.phpmyadmin.middlewares=${PHPMYADMIN_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.phpmyadmin.loadbalancer.server.port=80
       - com.centurylinklabs.watchtower.enable=${PHPMYADMIN_WATCHTOWER_ENABLED:-true}
       - autoheal=true

--- a/services-available/pihole.yml
+++ b/services-available/pihole.yml
@@ -40,6 +40,6 @@ services:
       - traefik.http.services.pihole.loadbalancer.server.scheme=https
       - traefik.http.middlewares.piholeredirect.redirectregex.regex=^https?://${PIHOLE_CONTAINER_NAME:-pihole}.${HOST_DOMAIN}/$$
       - traefik.http.middlewares.piholeredirect.redirectregex.replacement=http://${PIHOLE_CONTAINER_NAME:-pihole}.${HOST_DOMAIN}/admin/
-      - traefik.http.routers.pihole.middlewares=piholeredirect
+      - traefik.http.routers.pihole.middlewares=${PIHOLE_MIDDLEWARES:-default-headers@file,piholeredirect,noindex-headers@file}
       - com.centurylinklabs.watchtower.enable=${PIHOLE_WATCHTOWER_ENABLED:-true}
       - autoheal=true

--- a/services-available/pinchflat.yml
+++ b/services-available/pinchflat.yml
@@ -28,7 +28,7 @@ services:
       - traefik.enable=${PINCHFLAT_TRAEFIK_ENABLED:-true}
       - traefik.http.routers.pinchflat.entrypoints=websecure
       - traefik.http.routers.pinchflat.rule=Host(`${PINCHFLAT_HOST_NAME:-pinchflat}.${HOST_DOMAIN}`)
-      - traefik.http.routers.pinchflat.middlewares=default-headers@file
+      - traefik.http.routers.pinchflat.middlewares=${PINCHFLAT_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       #- traefik.http.services.pinchflat.loadbalancer.server.scheme=https # enable if the service wants to connect over https
       - traefik.http.services.pinchflat.loadbalancer.server.port=8945
       - com.centurylinklabs.watchtower.enable=${PINCHFLAT_WATCHTOWER_ENABLED:-true}

--- a/services-available/pingvin-share.yml
+++ b/services-available/pingvin-share.yml
@@ -27,6 +27,7 @@ services:
       - traefik.enable=${PINGVIN_SHARE_TRAEFIK_ENABLE:-true}
       - traefik.http.routers.pingvin.entrypoints=websecure
       - traefik.http.routers.pingvin.rule=Host(`${PINGVIN_SHARE_CONTAINER_NAME:-pingvin}.${HOST_DOMAIN}`)
+      - traefik.http.routers.pingvin.middlewares=${PINGVIN_SHARE_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.pingvin.loadbalancer.server.port=3000
       - com.centurylinklabs.watchtower.enable=${PINGVIN_SHARE_WATCHTOWER_ENABLE:-true}
       - autoheal=${PINGVIN_SHARE_AUTOHEAL:-true}

--- a/services-available/plex.yml
+++ b/services-available/plex.yml
@@ -43,6 +43,7 @@ services:
       - traefik.enable=${PLEX_TRAEFIK_ENABLE:-true}
       - traefik.http.routers.plex.entrypoints=websecure
       - traefik.http.routers.plex.rule=Host(`${PLEX_CONTAINER_NAME:-plex}.${HOST_DOMAIN}`)
+      - traefik.http.routers.plex.middlewares=${PLEX_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.plex.loadbalancer.server.port=32400
       - com.centurylinklabs.watchtower.enable=${PLEX_WATCHTOWER_ENABLE:-true}
       - autoheal=${PLEX_AUTOHEAL:-true}

--- a/services-available/pocketbase.yml
+++ b/services-available/pocketbase.yml
@@ -33,6 +33,7 @@ services:
       - traefik.enable=${POCKETBASE_TRAEFIK_ENABLED:-true}
       - traefik.http.routers.pocketbase.entrypoints=websecure
       - traefik.http.routers.pocketbase.rule=Host(`${POCKETBASE_HOST_NAME:-pocketbase}.${HOST_DOMAIN}`)
+      - traefik.http.routers.pocketbase.middlewares=${POCKETBASE_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.pocketbase.loadbalancer.server.port=8090
       - com.centurylinklabs.watchtower.enable=${POCKETBASE_WATCHTOWER_ENABLED:-true}
       - autoheal=${POCKETBASE_AUTOHEAL_ENABLED:-true}

--- a/services-available/portainer-ee.yml
+++ b/services-available/portainer-ee.yml
@@ -23,6 +23,7 @@ services:
       - traefik.enable=true
       - traefik.http.routers.portainer.entrypoints=websecure
       - traefik.http.routers.portainer.rule=Host(`portainer-ee.${HOST_DOMAIN}`)
+      - traefik.http.routers.portainer.middlewares=${PORTAINER_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.portainer.loadbalancer.server.port=9000
       - com.centurylinklabs.watchtower.enable=${PORTAINER_WATCHTOWER_ENABLED:-true}
       - autoheal=true

--- a/services-available/portainer.yml
+++ b/services-available/portainer.yml
@@ -25,6 +25,7 @@ services:
       - traefik.enable=true
       - traefik.http.routers.portainer.entrypoints=websecure
       - traefik.http.routers.portainer.rule=Host(`${PORTAINER_CONTAINER_NAME:-portainer}.${HOST_DOMAIN}`)
+      - traefik.http.routers.portainer.middlewares=${PORTAINER_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.portainer.loadbalancer.server.port=9000
       - com.centurylinklabs.watchtower.enable=${PORTAINER_WATCHTOWER_ENABLED:-true}
       - autoheal=true

--- a/services-available/postman.yml
+++ b/services-available/postman.yml
@@ -24,6 +24,7 @@ services:
       - traefik.enable=true
       - traefik.http.routers.postman.entrypoints=websecure
       - traefik.http.routers.postman.rule=Host(`${POSTMAN_CONTAINER_NAME:-hoppscotch}.${HOST_DOMAIN}`)
+      - traefik.http.routers.postman.middlewares=${POSTMAN_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.postman.loadbalancer.server.port=3000
       - com.centurylinklabs.watchtower.enable=${POSTMAN_WATCHTOWER_ENABLED:-true}
       - autoheal=true

--- a/services-available/prestashop.yml
+++ b/services-available/prestashop.yml
@@ -29,6 +29,7 @@ services:
       - traefik.enable=true
       - traefik.http.routers.prestashop.entrypoints=websecure
       - traefik.http.routers.prestashop.rule=Host(`${PRESTASHOP_CONTAINER_NAME:-prestashop}.${HOST_DOMAIN}`)
+      - traefik.http.routers.prestashop.middlewares=${PRESTASHOP_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.prestashop.loadbalancer.server.port=80
       - com.centurylinklabs.watchtower.enable=${PRESTASHOP_WATCHTOWER_ENABLED:-true}
       - autoheal=true

--- a/services-available/prometheus-alertmanager.yml
+++ b/services-available/prometheus-alertmanager.yml
@@ -32,5 +32,6 @@ services:
       - traefik.enable=true
       - traefik.http.routers.alertmanager.rule=Host(`${ALERTMANAGER_HOST_NAME:-alertmanager}.${HOST_DOMAIN}`)
       - traefik.http.routers.alertmanager.entrypoints=websecure
+      - traefik.http.routers.alertmanager.middlewares=${ALERTMANAGER_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.alertmanager.loadbalancer.server.port=9093
       - com.centurylinklabs.watchtower.enable=${ALERTMANAGER_WATCHTOWER_ENABLED:-true}

--- a/services-available/prometheus-all.yml
+++ b/services-available/prometheus-all.yml
@@ -40,6 +40,7 @@ services:
       - traefik.docker.network=traefik
       - traefik.http.routers.prometheus.rule=Host(`prometheus.${HOST_DOMAIN}`)
       - traefik.http.routers.prometheus.entrypoints=websecure
+      - traefik.http.routers.prometheus.middlewares=${PROMETHEUS_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.prometheus.loadbalancer.server.scheme=http
       - traefik.http.services.prometheus.loadbalancer.server.port=9090
 
@@ -79,6 +80,7 @@ services:
       - traefik.http.routers.blackbox.entrypoints=websecure
       - traefik.http.routers.blackbox.tls=true
       - traefik.http.routers.blackbox.tls.certresolver=letsencrypt
+      - traefik.http.routers.blackbox.middlewares=${PROMETHEUS_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.blackbox.loadbalancer.server.scheme=http
       - traefik.http.services.blackbox.loadbalancer.server.port=9115
 
@@ -106,6 +108,7 @@ services:
       - traefik.http.routers.alertmanager.entrypoints=websecure
       - traefik.http.routers.alertmanager.tls=true
       - traefik.http.routers.alertmanager.tls.certresolver=letsencrypt
+      - traefik.http.routers.alertmanager.middlewares=${PROMETHEUS_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.alertmanager.loadbalancer.server.scheme=http
       - traefik.http.services.alertmanager.loadbalancer.server.port=9093
 

--- a/services-available/prometheus-blackbox-exporter.yml
+++ b/services-available/prometheus-blackbox-exporter.yml
@@ -28,6 +28,7 @@ services:
       - traefik.enable=true
       - traefik.http.routers.blackbox.rule=Host(`blackbox.${HOST_DOMAIN}`)
       - traefik.http.routers.blackbox.entrypoints=websecure
+      - traefik.http.routers.blackbox.middlewares=${BLACKBOX_EXPORTER_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.blackbox.loadbalancer.server.port=9115
       - com.centurylinklabs.watchtower.enable=${BLACKBOX_EXPORTER_WATCHTOWER_ENABLED:-true}
       - autoheal=true

--- a/services-available/prometheus.yml
+++ b/services-available/prometheus.yml
@@ -36,6 +36,7 @@ services:
       - traefik.docker.network=traefik # required
       - traefik.http.routers.prometheus.rule=Host(`${PROMETHEUS_HOST_NAME:-prometheus}.${HOST_DOMAIN}`)
       - traefik.http.routers.prometheus.entrypoints=websecure
+      - traefik.http.routers.prometheus.middlewares=${PROMETHEUS_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.prometheus.loadbalancer.server.port=9090
       - com.centurylinklabs.watchtower.enable=${PROMETHEUS_WATCHTOWER_ENABLED:-true}
       - autoheal=true

--- a/services-available/prowlarr.yml
+++ b/services-available/prowlarr.yml
@@ -35,6 +35,7 @@ services:
       - traefik.enable=${PROWLARR_TRAEFIK_ENABLE:-true}
       - traefik.http.routers.prowlarr.entrypoints=websecure
       - traefik.http.routers.prowlarr.rule=Host(`${PROWLARR_CONTAINER_NAME:-prowlarr}.${HOST_DOMAIN}`)
+      - traefik.http.routers.prowlarr.middlewares=${PROWLARR_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.prowlarr.loadbalancer.server.port=9696
       - com.centurylinklabs.watchtower.enable=${PROWLARR_WATCHTOWER_ENABLE:-true}
       - autoheal=${PROWLARR_AUTOHEAL:-true}

--- a/services-available/pterodactyl-panel.yml
+++ b/services-available/pterodactyl-panel.yml
@@ -44,6 +44,7 @@ services:
       - traefik.enable=true
       - traefik.http.routers.pterodactyl-panel.entrypoints=websecure
       - traefik.http.routers.pterodactyl-panel.rule=Host(`${PTERODACTYL_PANEL_CONTAINER_NAME:-panel}.${HOST_DOMAIN}`)
+      - traefik.http.routers.pterodactyl-panel.middlewares=${PTERODACTYL_PANEL_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.pterodactyl-panel.loadbalancer.server.port=80
       - com.centurylinklabs.watchtower.enable=${PTERODACTYL_WATCHTOWER_ENABLED:-true}
       - autoheal=true

--- a/services-available/pterodactyl-wings.yml
+++ b/services-available/pterodactyl-wings.yml
@@ -29,6 +29,7 @@ services:
       - traefik.enable=true
       - traefik.http.routers.pterodactyl-wings.entrypoints=websecure
       - traefik.http.routers.pterodactyl-wings.rule=Host(`${PTERODACTYL_WINGS_CONTAINER_NAME:-pterodactyl-wings}.${HOST_DOMAIN}`)
+      - traefik.http.routers.pterodactyl-wings.middlewares=${PTERODACTYL_WINGS_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       #- traefik.http.services.pterodactyl-wings.loadbalancer.server.scheme=https # enable if the service wants to connect over https
       - traefik.http.services.pterodactyl-wings.loadbalancer.server.port=8096
       - com.centurylinklabs.watchtower.enable=${PTERODACTYL_WINGS_WATCHTOWER_ENABLED:-true}

--- a/services-available/pulse.yml
+++ b/services-available/pulse.yml
@@ -31,6 +31,7 @@ services:
       - traefik.enable=${PULSE_TRAEFIK_ENABLED:-true}
       - traefik.http.routers.pulse.entrypoints=websecure
       - traefik.http.routers.pulse.rule=Host(`${PULSE_HOST_NAME:-pulse}.${HOST_DOMAIN}`)
+      - traefik.http.routers.pulse.middlewares=${PULSE_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       #- traefik.http.services.pulse.loadbalancer.server.scheme=https # enable if the service wants to connect over https
       - traefik.http.services.pulse.loadbalancer.server.port=7655
       - com.centurylinklabs.watchtower.enable=${PULSE_WATCHTOWER_ENABLED:-true}

--- a/services-available/pwndrop.yml
+++ b/services-available/pwndrop.yml
@@ -28,6 +28,7 @@ services:
       - traefik.enable=${PWNDROP_TRAEFIK_ENABLE:-true}
       - traefik.http.routers.pwndrop.entrypoints=websecure
       - traefik.http.routers.pwndrop.rule=Host(`${PWNDROP_CONTAINER_NAME:-pwndrop}.${HOST_DOMAIN}`)
+      - traefik.http.routers.pwndrop.middlewares=${PWNDROP_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.pwndrop.loadbalancer.server.port=8080
       - com.centurylinklabs.watchtower.enable=${PWNDROP_WATCHTOWER_ENABLE:-true}
       - autoheal=${PWNDROP_AUTOHEAL:-true}

--- a/services-available/qdirstat.yml
+++ b/services-available/qdirstat.yml
@@ -30,6 +30,7 @@ services:
       - traefik.enable=true
       - traefik.http.routers.qdirstat.entrypoints=websecure
       - traefik.http.routers.qdirstat.rule=Host(`${QDIRSTAT_CONTAINER_NAME:-qdirstat}.${HOST_DOMAIN}`)
+      - traefik.http.routers.qdirstat.middlewares=${QDIRSTAT_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.qdirstat.loadbalancer.server.port=3000
       - com.centurylinklabs.watchtower.enable=${QDIRSTAT_WATCHTOWER_ENABLED:-true}
       - autoheal=true

--- a/services-available/rackula.yml
+++ b/services-available/rackula.yml
@@ -30,6 +30,7 @@ services:
       - traefik.enable=${RACKULA_TRAEFIK_ENABLED:-true}
       - traefik.http.routers.rackula.entrypoints=websecure
       - traefik.http.routers.rackula.rule=Host(`${RACKULA_HOST_NAME:-rackula}.${HOST_DOMAIN}`)
+      - traefik.http.routers.rackula.middlewares=${RACKULA_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.rackula.loadbalancer.server.port=80
       - com.centurylinklabs.watchtower.enable=${RACKULA_WATCHTOWER_ENABLED:-true}
       - autoheal=${RACKULA_AUTOHEAL_ENABLED:-true}

--- a/services-available/radarr.yml
+++ b/services-available/radarr.yml
@@ -40,6 +40,7 @@ services:
       - traefik.enable=${RADARR_TRAEFIK_ENABLE:-true}
       - traefik.http.routers.radarr.entrypoints=websecure
       - traefik.http.routers.radarr.rule=Host(`${RADARR_CONTAINER_NAME:-radarr}.${HOST_DOMAIN}`)
+      - traefik.http.routers.radarr.middlewares=${RADARR_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.radarr.loadbalancer.server.port=7878
       - com.centurylinklabs.watchtower.enable=${RADARR_WATCHTOWER_ENABLE:-true}
       - autoheal=${RADARR_AUTOHEAL:-true}

--- a/services-available/readarr.yml
+++ b/services-available/readarr.yml
@@ -39,6 +39,7 @@ services:
       - traefik.enable=${READARR_TRAEFIK_ENABLE:-true}
       - traefik.http.routers.readarr.entrypoints=websecure
       - traefik.http.routers.readarr.rule=Host(`${READARR_CONTAINER_NAME:-readarr}.${HOST_DOMAIN}`)
+      - traefik.http.routers.readarr.middlewares=${READARR_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.readarr.loadbalancer.server.port=8787
       - com.centurylinklabs.watchtower.enable=${READARR_WATCHTOWER_ENABLE:-true}
       - autoheal=${READARR_AUTOHEAL:-true}

--- a/services-available/redlib.yml
+++ b/services-available/redlib.yml
@@ -40,6 +40,7 @@ services:
       - traefik.enable=${REDLIB_TRAEFIK_ENABLED:-true}
       - traefik.http.routers.redlib.entrypoints=websecure
       - traefik.http.routers.redlib.rule=Host(`${REDLIB_HOST_NAME:-redlib}.${HOST_DOMAIN}`)
+      - traefik.http.routers.redlib.middlewares=${REDLIB_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.redlib.loadbalancer.server.port=8080
       - com.centurylinklabs.watchtower.enable=${REDLIB_WATCHTOWER_ENABLED:-true}
       - autoheal=${REDLIB_AUTOHEAL_ENABLED:-true}

--- a/services-available/remotely.yml
+++ b/services-available/remotely.yml
@@ -29,6 +29,6 @@ services:
       - traefik.http.routers.remotely.rule=Host(`${REMOTELY_CONTAINER_NAME:-remotely}.${HOST_DOMAIN}`)
       - traefik.http.services.remotely.loadbalancer.server.port=8080
       - traefik.http.services.remotely.loadbalancer.server.scheme=http
-      - traefik.http.routers.remotely.middlewares=default-headers@file
+      - traefik.http.routers.remotely.middlewares=${REMOTELY_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - com.centurylinklabs.watchtower.enable=${REMOTELY_WATCHTOWER_ENABLED:-true}
       - autoheal=true

--- a/services-available/requestrr.yml
+++ b/services-available/requestrr.yml
@@ -27,6 +27,7 @@ services:
       - traefik.enable=true
       - traefik.http.routers.requestrr.entrypoints=websecure
       - traefik.http.routers.requestrr.rule=Host(`requestrr.${HOST_DOMAIN}`)
+      - traefik.http.routers.requestrr.middlewares=${REQUESTRR_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.requestrr.loadbalancer.server.port=4545
       - com.centurylinklabs.watchtower.enable=${REQUESTRR_WATCHTOWER_ENABLED:-true}
       - autoheal=true

--- a/services-available/rundeck.yml
+++ b/services-available/rundeck.yml
@@ -31,6 +31,7 @@ services:
       - traefik.enable=true
       - traefik.http.routers.rundeck.entrypoints=websecure
       - traefik.http.routers.rundeck.rule=Host(`${RUNDECK_CONTAINER_NAME:-rundeck}.${HOST_DOMAIN}`)
+      - traefik.http.routers.rundeck.middlewares=${RUNDECK_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       #- traefik.http.services.rundeck.loadbalancer.server.scheme=https # enable if the service wants to connect over https
       - traefik.http.services.rundeck.loadbalancer.server.port=4440
       - com.centurylinklabs.watchtower.enable=${RUNDECK_WATCHTOWER_ENABLED:-true}

--- a/services-available/rwmarkable.yml
+++ b/services-available/rwmarkable.yml
@@ -45,6 +45,7 @@ services:
       - traefik.enable=${RWMARKABLE_TRAEFIK_ENABLED:-true}
       - traefik.http.routers.rwmarkable.entrypoints=websecure
       - traefik.http.routers.rwmarkable.rule=Host(`${RWMARKABLE_HOST_NAME:-rwmarkable}.${HOST_DOMAIN}`)
+      - traefik.http.routers.rwmarkable.middlewares=${RWMARKABLE_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       #- traefik.http.services.rwmarkable.loadbalancer.server.scheme=https # enable if the service wants to connect over >      
       - traefik.http.services.rwmarkable.loadbalancer.server.port=3000
       - com.centurylinklabs.watchtower.enable=${RWMARKABLE_WATCHTOWER_ENABLED:-true}

--- a/services-available/sablier.yml
+++ b/services-available/sablier.yml
@@ -30,6 +30,7 @@ services:
       - traefik.enable=true
       - traefik.http.routers.sablier.entrypoints=websecure
       - traefik.http.routers.sablier.rule=Host(`${SABLIER_CONTAINER_NAME:-sablier}.${HOST_DOMAIN}`)
+      - traefik.http.routers.sablier.middlewares=${SABLIER_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       #- traefik.http.services.sablier.loadbalancer.server.scheme=https # enable if the service wants to connect over https
       - traefik.http.services.sablier.loadbalancer.server.port=10000
       - traefik.http.middlewares.dynamic.plugin.sablier.names=sablier_whoami_1

--- a/services-available/sabnzbd.yml
+++ b/services-available/sabnzbd.yml
@@ -37,6 +37,7 @@ services:
       - traefik.enable=${SABNZBD_TRAEFIK_ENABLE:-true}
       - traefik.http.routers.sabnzbd.entrypoints=websecure
       - traefik.http.routers.sabnzbd.rule=Host(`${SABNZBD_CONTAINER_NAME:-sabnzbd}.${HOST_DOMAIN}`)
+      - traefik.http.routers.sabnzbd.middlewares=${SABNZBD_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.sabnzbd.loadbalancer.server.port=8080
       - com.centurylinklabs.watchtower.enable=${SABNZBD_WATCHTOWER_ENABLE:-true}
       - autoheal=${SABNZBD_AUTOHEAL:-true}

--- a/services-available/scrypted.yml
+++ b/services-available/scrypted.yml
@@ -35,6 +35,7 @@ services:
       - traefik.enable=true
       - traefik.http.routers.scrypted.entrypoints=websecure
       - traefik.http.routers.scrypted.rule=Host(`${SCRYPTED_CONTAINER_NAME:-scrypted}.${HOST_DOMAIN}`)
+      - traefik.http.routers.scrypted.middlewares=${SCRYPTED_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.scrypted.loadbalancer.server.port=10443
       - traefik.http.services.scrypted.loadbalancer.server.scheme=https
       - com.centurylinklabs.watchtower.enable=${SCRYPTED_WATCHTOWER_ENABLED:-true}

--- a/services-available/sd-web.yml
+++ b/services-available/sd-web.yml
@@ -34,6 +34,7 @@ services:
       - traefik.enable=true
       - traefik.http.routers.sd-web.entrypoints=websecure
       - traefik.http.routers.sd-web.rule=Host(`${SD_WEB_CONTAINER_NAME:-sd-web}.${HOST_DOMAIN}`)
+      - traefik.http.routers.sd-web.middlewares=${SD_WEB_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.sd-web.loadbalancer.server.port=7860
       - com.centurylinklabs.watchtower.enable=${SD_WEB_WATCHTOWER_ENABLED:-true}
       - autoheal=true

--- a/services-available/searxng.yml
+++ b/services-available/searxng.yml
@@ -42,6 +42,7 @@ services:
       - traefik.enable=true
       - traefik.http.routers.searxng.entrypoints=websecure
       - traefik.http.routers.searxng.rule=Host(`${SEARXNG_CONTAINER_NAME:-searxng}.${HOST_DOMAIN}`)
+      - traefik.http.routers.searxng.middlewares=${SEARXNG_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.searxng.loadbalancer.server.port=8080
       - com.centurylinklabs.watchtower.enable=${SEARXNG_WATCHTOWER_ENABLED:-true}
       - autoheal=true

--- a/services-available/seerr.yml
+++ b/services-available/seerr.yml
@@ -34,6 +34,7 @@ services:
       - traefik.enable=${SEERR_TRAEFIK_ENABLE:-true}
       - traefik.http.routers.seerr.entrypoints=websecure
       - traefik.http.routers.seerr.rule=Host(`${SEERR_CONTAINER_NAME:-seerr}.${HOST_DOMAIN}`)
+      - traefik.http.routers.seerr.middlewares=${SEERR_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.seerr.loadbalancer.server.port=5055
       - com.centurylinklabs.watchtower.enable=${SEERR_WATCHTOWER_ENABLE:-true}
       - autoheal=${SEERR_AUTOHEAL:-true}

--- a/services-available/semaphore.yml
+++ b/services-available/semaphore.yml
@@ -74,6 +74,7 @@ services:
       - traefik.enable=true
       - traefik.http.routers.semaphore.entrypoints=websecure
       - traefik.http.routers.semaphore.rule=Host(`${SEMAPHORE_CONTAINER_NAME:-semaphore}.${HOST_DOMAIN}`)
+      - traefik.http.routers.semaphore.middlewares=${SEMAPHORE_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.semaphore.loadbalancer.server.scheme=http
       - traefik.http.services.semaphore.loadbalancer.server.port=3000
       - com.centurylinklabs.watchtower.enable=${SEMAPHORE_WATCHTOWER_ENABLED:-true}

--- a/services-available/sftp-server.yml
+++ b/services-available/sftp-server.yml
@@ -28,6 +28,7 @@ services:
       - traefik.enable=true
       - traefik.http.routers.sftp-server.entrypoints=websecure
       - traefik.http.routers.sftp-server.rule=Host(`${SFTP_SERVER_CONTAINER_NAME:-sftp-server}.${HOST_DOMAIN}`)
+      - traefik.http.routers.sftp-server.middlewares=${SFTP_SERVER_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.sftp-server.loadbalancer.server.port=8080
       - com.centurylinklabs.watchtower.enable=${SFTP_SERVER_WATCHTOWER_ENABLED:-true}
       - autoheal=true

--- a/services-available/shlink.yml
+++ b/services-available/shlink.yml
@@ -31,6 +31,7 @@ services:
       - traefik.enable=${SHLINK_TRAEFIK_ENABLED:-true}
       - traefik.http.routers.shlink.entrypoints=websecure
       - traefik.http.routers.shlink.rule=Host(`${SHLINK_HOST_NAME:-shlink}.${HOST_DOMAIN}`)
+      - traefik.http.routers.shlink.middlewares=${SHLINK_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       #- traefik.http.services.shlink.loadbalancer.server.scheme=https # enable if the service wants to connect over https
       - traefik.http.services.shlink.loadbalancer.server.port=8080
       - com.centurylinklabs.watchtower.enable=${SHLINK_WATCHTOWER_ENABLED:-true}

--- a/services-available/snapdrop.yml
+++ b/services-available/snapdrop.yml
@@ -25,6 +25,7 @@ services:
       - traefik.enable=${SNAPDROP_TRAEFIK_ENABLE:-true}
       - traefik.http.routers.snapdrop.entrypoints=websecure
       - traefik.http.routers.snapdrop.rule=Host(`${SNAPDROP_CONTAINER_NAME:-snapdrop}.${HOST_DOMAIN}`)
+      - traefik.http.routers.snapdrop.middlewares=${SNAPDROP_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.snapdrop.loadbalancer.server.port=80
       - com.centurylinklabs.watchtower.enable=${SNAPDROP_WATCHTOWER_ENABLE:-true}
       - autoheal=${SNAPDROP_AUTOHEAL:-true}

--- a/services-available/sonarr.yml
+++ b/services-available/sonarr.yml
@@ -37,6 +37,7 @@ services:
       - traefik.enable=${SONARR_TRAEFIK_ENABLE:-true}
       - traefik.http.routers.sonarr.entrypoints=websecure
       - traefik.http.routers.sonarr.rule=Host(`${SONARR_CONTAINER_NAME:-sonarr}.${HOST_DOMAIN}`)
+      - traefik.http.routers.sonarr.middlewares=${SONARR_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.sonarr.loadbalancer.server.port=8989
       - com.centurylinklabs.watchtower.enable=${SONARR_WATCHTOWER_ENABLE:-true}
       - autoheal=${SONARR_AUTOHEAL:-true}

--- a/services-available/spacebin.yml
+++ b/services-available/spacebin.yml
@@ -33,7 +33,7 @@ services:
       - traefik.http.routers.spacebin.rule=Host(`${SPACEBIN_HOST_NAME:-spacebin}.${HOST_DOMAIN}`)
       #- traefik.http.services.spacebin.loadbalancer.server.scheme=https # enable if the service wants to connect over https
       - traefik.http.services.spacebin.loadbalancer.server.port=9000
-      - traefik.http.routers.spacebin.middlewares=default-headers@file
+      - traefik.http.routers.spacebin.middlewares=${SPACEBIN_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - com.centurylinklabs.watchtower.enable=${SPACEBIN_WATCHTOWER_ENABLED:-true}
       - autoheal=${SPACEBIN_AUTOHEAL_ENABLED:-true}
   spacebin-db:

--- a/services-available/speedtest-tracker.yml
+++ b/services-available/speedtest-tracker.yml
@@ -42,6 +42,7 @@ services:
       - traefik.enable=${SPEEDTEST_TRACKER_TRAEFIK_ENABLED:-true}
       - traefik.http.routers.speedtest-tracker.entrypoints=websecure
       - traefik.http.routers.speedtest-tracker.rule=Host(`${SPEEDTEST_TRACKER_HOST_NAME:-speedtest}.${HOST_DOMAIN}`)
+      - traefik.http.routers.speedtest-tracker.middlewares=${SPEEDTEST_TRACKER_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.speedtest-tracker.loadbalancer.server.port=80
       - com.centurylinklabs.watchtower.enable=${SPEEDTEST_TRACKER_WATCHTOWER_ENABLED:-true}
       - autoheal=${SPEEDTEST_TRACKER_AUTOHEAL_ENABLED:-true}

--- a/services-available/sqliteweb.yml
+++ b/services-available/sqliteweb.yml
@@ -28,6 +28,7 @@ services:
       - traefik.enable=${SQLITEWEB_TRAEFIK_ENABLED:-true}
       - traefik.http.routers.sqliteweb.entrypoints=websecure
       - traefik.http.routers.sqliteweb.rule=Host(`${SQLITEWEB_CONTAINER_NAME:-sqliteweb}.${HOST_DOMAIN}`)
+      - traefik.http.routers.sqliteweb.middlewares=${SQLITEWEB_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.sqliteweb.loadbalancer.server.port=8080
       - com.centurylinklabs.watchtower.enable=${SQLITEWEB_WATCHTOWER_ENABLED:-true}
       - autoheal=${SQLITEWEB_AUTOHEAL_ENABLED:-true}

--- a/services-available/stirling-pdf.yml
+++ b/services-available/stirling-pdf.yml
@@ -30,7 +30,7 @@ services:
       - traefik.http.routers.stirling-pdf.entrypoints=websecure
       - traefik.http.routers.stirling-pdf.rule=Host(`${STIRLING_PDF_CONTAINER_NAME:-stirling-pdf}.${HOST_DOMAIN}`)
       - traefik.http.middlewares.limit.buffering.maxRequestBodyBytes=10000000000
-      - traefik.http.routers.stirling-pdf.middlewares=limit
+      - traefik.http.routers.stirling-pdf.middlewares=${STIRLING_PDF_MIDDLEWARES:-default-headers@file,limit,noindex-headers@file}
       - traefik.http.services.stirling-pdf.loadbalancer.server.port=8080
       - com.centurylinklabs.watchtower.enable=${STIRLING_PDF_WATCHTOWER_ENABLED:-true}
       - autoheal=true

--- a/services-available/streaming-search.yml
+++ b/services-available/streaming-search.yml
@@ -26,6 +26,7 @@ services:
       - traefik.enable=true
       - traefik.http.routers.streaming-search.entrypoints=websecure
       - traefik.http.routers.streaming-search.rule=Host(`${STREAMING_SEARCH_CONTAINER_NAME:-streaming-search}.${HOST_DOMAIN}`)
+      - traefik.http.routers.streaming-search.middlewares=${STREAMING_SEARCH_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.streaming-search.loadbalancer.server.port=8000
       - com.centurylinklabs.watchtower.enable=${STREAMING_SEARCH_WATCHTOWER_ENABLED:-true}
       - autoheal=true

--- a/services-available/super-productivity.yml
+++ b/services-available/super-productivity.yml
@@ -27,6 +27,7 @@ services:
       - traefik.enable=true
       - traefik.http.routers.super-productivity.entrypoints=websecure
       - traefik.http.routers.super-productivity.rule=Host(`${SUPER_PRODUCTIVITY_CONTAINER_NAME:-super-productivity}.${HOST_DOMAIN}`)
+      - traefik.http.routers.super-productivity.middlewares=${SUPER_PRODUCTIVITY_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       #- traefik.http.services.super-productivity.loadbalancer.server.scheme=https # enable if the service wants to connect over https
       - traefik.http.services.super-productivity.loadbalancer.server.port=80
       - com.centurylinklabs.watchtower.enable=${SUPER_PRODUCTIVITY_WATCHTOWER_ENABLED:-true}

--- a/services-available/surrealdb.yml
+++ b/services-available/surrealdb.yml
@@ -37,6 +37,7 @@ services:
       - traefik.enable=${SURREALDB_TRAEFIK_ENABLED:-true}
       - traefik.http.routers.surrealdb.entrypoints=websecure
       - traefik.http.routers.surrealdb.rule=Host(`${SURREALDB_CONTAINER_NAME:-surrealdb}.${HOST_DOMAIN}`)
+      - traefik.http.routers.surrealdb.middlewares=${SURREALDB_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.surrealdb.loadbalancer.server.port=8000
       - com.centurylinklabs.watchtower.enable=${SURREALDB_WATCHTOWER_ENABLED:-true}
       - autoheal=${SURREALDB_AUTOHEAL_ENABLED:-true}

--- a/services-available/synapse.yml
+++ b/services-available/synapse.yml
@@ -28,6 +28,7 @@ services:
       - traefik.enable=true
       - traefik.http.routers.synapse.entrypoints=websecure
       - traefik.http.routers.synapse.rule=Host(`${SYNAPSE_CONTAINER_NAME:-synapse}.${HOST_DOMAIN}`)
+      - traefik.http.routers.synapse.middlewares=${SYNAPSE_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.synapse.loadbalancer.server.port=8008
       - com.centurylinklabs.watchtower.enable=${SYNAPSE_WATCHTOWER_ENABLED:-true}
       - autoheal=true

--- a/services-available/synchronet.yml
+++ b/services-available/synchronet.yml
@@ -57,6 +57,7 @@ services:
       - traefik.enable=${SYNCHRONET_TRAEFIK_ENABLED:-true}
       - traefik.http.routers.synchronet.entrypoints=websecure
       - traefik.http.routers.synchronet.rule=Host(`${SYNCHRONET_CONTAINER_NAME:-synchronet}.${HOST_DOMAIN}`)
+      - traefik.http.routers.synchronet.middlewares=${SYNCHRONET_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       #- traefik.http.services.synchronet.loadbalancer.server.scheme=https # enable if the service wants to connect over https
       - traefik.http.services.synchronet.loadbalancer.server.port=443
       - com.centurylinklabs.watchtower.enable=${SYNCHRONET_WATCHTOWER_ENABLED:-true}

--- a/services-available/syncthing.yml
+++ b/services-available/syncthing.yml
@@ -35,6 +35,7 @@ services:
       - traefik.enable=${SYNCTHING_TRAEFIK_ENABLE:-true}
       - traefik.http.routers.sync.entrypoints=websecure
       - traefik.http.routers.sync.rule=Host(`${SYNCTHING_CONTAINER_NAME:-syncthing}.${HOST_DOMAIN}`)
+      - traefik.http.routers.sync.middlewares=${SYNCTHING_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.sync.loadbalancer.server.port=8384
       - com.centurylinklabs.watchtower.enable=${SYNCTHING_WATCHTOWER_ENABLE:-true}
       - autoheal=${SYNCTHING_AUTOHEAL:-true}

--- a/services-available/tandoor.yml
+++ b/services-available/tandoor.yml
@@ -71,6 +71,7 @@ services:
       - traefik.docker.network=traefik
       - traefik.http.routers.tandoor.entrypoints=websecure
       - traefik.http.routers.tandoor.rule=Host(`${TANDOOR_HOST_NAME:-recipe}.${HOST_DOMAIN}`)
+      - traefik.http.routers.tandoor.middlewares=${TANDOORDB_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       #- traefik.http.services.tandoor.loadbalancer.server.scheme=https # enable if the service wants to connect over https
       - com.centurylinklabs.watchtower.enable=${TANDOOR_WATCHTOWER_ENABLED:-true}
       - traefik.http.services.tandoor.loadbalancer.server.port=80

--- a/services-available/tasktrove.yml
+++ b/services-available/tasktrove.yml
@@ -29,6 +29,7 @@ services:
       - traefik.enable=${TASKTROVE_TRAEFIK_ENABLED:-true}
       - traefik.http.routers.tasktrove.entrypoints=websecure
       - traefik.http.routers.tasktrove.rule=Host(`${TASKTROVE_HOST_NAME:-tasktrove}.${HOST_DOMAIN}`)
+      - traefik.http.routers.tasktrove.middlewares=${TASKTROVE_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.tasktrove.loadbalancer.server.port=3000
       - com.centurylinklabs.watchtower.enable=${TASKTROVE_WATCHTOWER_ENABLED:-true}
       - autoheal=${TASKTROVE_AUTOHEAL_ENABLED:-true}

--- a/services-available/tautulli.yml
+++ b/services-available/tautulli.yml
@@ -25,6 +25,7 @@ services:
       - traefik.enable=true
       - traefik.http.routers.tautulli.entrypoints=websecure
       - traefik.http.routers.tautulli.rule=Host(`tautulli.${HOST_DOMAIN}`)
+      - traefik.http.routers.tautulli.middlewares=${TAUTULLI_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.tautulli.loadbalancer.server.port=8181
       - com.centurylinklabs.watchtower.enable=${TAUTULLI_WATCHTOWER_ENABLED:-true}
       - autoheal=true

--- a/services-available/tdarr.yml
+++ b/services-available/tdarr.yml
@@ -46,6 +46,7 @@ services:
       - traefik.enable=true
       - traefik.http.routers.tdarr.entrypoints=websecure
       - traefik.http.routers.tdarr.rule=Host(`${TDARR_CONTAINER_NAME:-tdarr}.${HOST_DOMAIN}`)
+      - traefik.http.routers.tdarr.middlewares=${TDARR_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.tdarr.loadbalancer.server.port=${TDARR_WEB_PORT:-8265}
       - com.centurylinklabs.watchtower.enable=${TDARR_WATCHTOWER_ENABLED:-true}
       - autoheal=true

--- a/services-available/transmission-vpn.yml
+++ b/services-available/transmission-vpn.yml
@@ -46,6 +46,7 @@ services:
       - traefik.docker.network=traefik
       - traefik.http.routers.transmission-vpn.entrypoints=websecure
       - traefik.http.routers.transmission-vpn.rule=Host(`${TRANSMISSION_VPN_CONTAINER_NAME:-transmission-vpn}.${HOST_DOMAIN}`)
+      - traefik.http.routers.transmission-vpn.middlewares=${TRANSMISSION_VPN_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.transmission-vpn.loadbalancer.server.port=9091
       - com.centurylinklabs.watchtower.enable=${TRANSMISSION_VPN_WATCHTOWER_ENABLED:-true}
       - traefik.http.services.transmission-vpn.loadbalancer.server.scheme=http

--- a/services-available/transmission.yml
+++ b/services-available/transmission.yml
@@ -37,6 +37,7 @@ services:
       - traefik.enable=${TRANSMISSION_TRAEFIK_ENABLED:-true}
       - traefik.http.routers.transmission.entrypoints=websecure
       - traefik.http.routers.transmission.rule=Host(`${TRANSMISSION_HOST_NAME:-transmission}.${HOST_DOMAIN}`)
+      - traefik.http.routers.transmission.middlewares=${TRANSMISSION_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.transmission.loadbalancer.server.port=9091
       - com.centurylinklabs.watchtower.enable=${TRANSMISSION_WATCHTOWER_ENABLED:-true}
       - autoheal=${TRANSMISSION_AUTOHEAL_ENABLED:-true}

--- a/services-available/trilium.yml
+++ b/services-available/trilium.yml
@@ -26,6 +26,7 @@ services:
       - traefik.enable=true
       - traefik.http.routers.trilium.entrypoints=websecure
       - traefik.http.routers.trilium.rule=Host(`${TRILIUM_CONTAINER_NAME:-trilium}.${HOST_DOMAIN}`)
+      - traefik.http.routers.trilium.middlewares=${TRILIUM_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.trilium.loadbalancer.server.port=8080
       - com.centurylinklabs.watchtower.enable=${TRILIUM_WATCHTOWER_ENABLED:-true}
       - autoheal=true

--- a/services-available/truecommand.yml
+++ b/services-available/truecommand.yml
@@ -26,6 +26,7 @@ services:
       - traefik.enable=true
       - traefik.http.routers.truecommand.entrypoints=websecure
       - traefik.http.routers.truecommand.rule=Host(`${TRUECOMMAND_CONTAINER_NAME:-truecommand}.${HOST_DOMAIN}`)
+      - traefik.http.routers.truecommand.middlewares=${TRUECOMMAND_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.truecommand.loadbalancer.server.port=80
       - com.centurylinklabs.watchtower.enable=${TRUECOMMAND_WATCHTOWER_ENABLED:-true}
       - autoheal=true

--- a/services-available/unifi.yml
+++ b/services-available/unifi.yml
@@ -39,6 +39,7 @@ services:
       - traefik.enable=${UNIFI_TRAEFIK_ENABLE:-true}
       - traefik.http.routers.unifi.entrypoints=websecure
       - traefik.http.routers.unifi.rule=Host(`${UNIFI_CONTAINER_NAME:-unifi}.${HOST_DOMAIN}`)
+      - traefik.http.routers.unifi.middlewares=${UNIFI_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.unifi.loadbalancer.server.scheme=https
       - traefik.http.services.unifi.loadbalancer.server.port=8443
       - com.centurylinklabs.watchtower.enable=${UNIFI_WATCHTOWER_ENABLE:-true}

--- a/services-available/unimus.yml
+++ b/services-available/unimus.yml
@@ -31,6 +31,7 @@ services:
       - traefik.docker.network=traefik
       - traefik.http.routers.unimus.entrypoints=websecure
       - traefik.http.routers.unimus.rule=Host(`${UNIMUS_CONTAINER_NAME:-unimus}.${HOST_DOMAIN}`)
+      - traefik.http.routers.unimus.middlewares=${UNIMUS_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.unimus.loadbalancer.server.port=8085
       - com.centurylinklabs.watchtower.enable=${UNIMUS_WATCHTOWER_ENABLED:-false}
       - autoheal=true

--- a/services-available/unmanic.yml
+++ b/services-available/unmanic.yml
@@ -30,6 +30,7 @@ services:
       - traefik.enable=${UNMANIC_TRAEFIK_ENABLED:-true}
       - traefik.http.routers.unmanic.entrypoints=websecure
       - traefik.http.routers.unmanic.rule=Host(`${UNMANIC_HOST_NAME:-unmanic}.${HOST_DOMAIN}`)
+      - traefik.http.routers.unmanic.middlewares=${UNMANIC_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       #- traefik.http.services.unmanic.loadbalancer.server.scheme=https # enable if the service wants to connect over https
       - traefik.http.services.unmanic.loadbalancer.server.port=8888
       - com.centurylinklabs.watchtower.enable=${UNMANIC_WATCHTOWER_ENABLED:-true}

--- a/services-available/uptime-kuma.yml
+++ b/services-available/uptime-kuma.yml
@@ -33,7 +33,7 @@ services:
       - traefik.http.routers.uptimekuma.rule=Host(`${UPTIMEKUMA_HOST_NAME:-uptimekuma}.${HOST_DOMAIN}`)
       - traefik.http.routers.uptimekuma.tls=true
       - traefik.http.routers.uptimekuma.service=uptimekuma
-      - traefik.http.routers.uptimekuma.middlewares=default-headers@file
+      - traefik.http.routers.uptimekuma.middlewares=${UPTIMEKUMA_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.uptimekuma.loadbalancer.server.port=3001
       - traefik.docker.network=traefik
       - com.centurylinklabs.watchtower.enable=${UPTIMEKUMA_WATCHTOWER_ENABLE:-true}

--- a/services-available/vault.yml
+++ b/services-available/vault.yml
@@ -44,6 +44,7 @@ services:
       - traefik.enable=${VAULT_TRAEFIK_ENABLED:-true}
       - traefik.http.routers.vault.entrypoints=websecure
       - traefik.http.routers.vault.rule=Host(`${VAULT_HOST_NAME:-vault}.${HOST_DOMAIN}`)
+      - traefik.http.routers.vault.middlewares=${VAULT_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       #- traefik.http.services.vault.loadbalancer.server.scheme=https # enable if the service wants to connect over https
       - traefik.http.services.vault.loadbalancer.server.port=8200
       - com.centurylinklabs.watchtower.enable=${VAULT_WATCHTOWER_ENABLED:-true}

--- a/services-available/vaultwarden.yml
+++ b/services-available/vaultwarden.yml
@@ -40,6 +40,7 @@ services:
       - traefik.enable=${VAULTWARDEN_TRAEFIK_ENABLE:-true}
       - traefik.http.routers.vaultwarden.entrypoints=websecure
       - traefik.http.routers.vaultwarden.rule=Host(`${VAULTWARDEN_HOSTNAME:-vaultwarden}.${HOST_DOMAIN}`)
+      - traefik.http.routers.vaultwarden.middlewares=${VAULTWARDEN_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.vaultwarden.loadbalancer.server.port=80
       - com.centurylinklabs.watchtower.enable=${VAULTWARDEN_WATCHTOWER_ENABLE:-true}
       - autoheal=${VAULTWARDEN_AUTOHEAL:-true}

--- a/services-available/vert.yml
+++ b/services-available/vert.yml
@@ -29,6 +29,7 @@ services:
       - traefik.enable=${VERT_TRAEFIK_ENABLED:-true}
       - traefik.http.routers.vert.entrypoints=websecure
       - traefik.http.routers.vert.rule=Host(`${VERT_HOST_NAME:-vert}.${HOST_DOMAIN}`)
+      - traefik.http.routers.vert.middlewares=${VERT_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       #- traefik.http.services.vert.loadbalancer.server.scheme=https # enable if the service wants to connect over https
       - traefik.http.services.vert.loadbalancer.server.port=3000
       - com.centurylinklabs.watchtower.enable=${VERT_WATCHTOWER_ENABLED:-true}

--- a/services-available/vikunja.yml
+++ b/services-available/vikunja.yml
@@ -33,6 +33,7 @@ services:
       - traefik.enable=true
       - traefik.http.routers.vikunja.entrypoints=websecure
       - traefik.http.routers.vikunja.rule=Host(`${VIKUNJA_CONTAINER_NAME:-vikunja}.${HOST_DOMAIN}`)
+      - traefik.http.routers.vikunja.middlewares=${VIKUNJA_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       #- traefik.http.services.vikunja.loadbalancer.server.scheme=https # enable if the service wants to connect over https
       - traefik.http.services.vikunja.loadbalancer.server.port=3456
       - com.centurylinklabs.watchtower.enable=${VIKUNJA_WATCHTOWER_ENABLED:-true}

--- a/services-available/wallabag.yml
+++ b/services-available/wallabag.yml
@@ -34,6 +34,7 @@ services:
       - traefik.enable=true
       - traefik.http.routers.wallabag.entrypoints=websecure
       - traefik.http.routers.wallabag.rule=Host(`${WALLABAG_CONTAINER_NAME:-wallabag}.${HOST_DOMAIN}`)
+      - traefik.http.routers.wallabag.middlewares=${WALLABAG_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.wallabag.loadbalancer.server.port=80
       - com.centurylinklabs.watchtower.enable=${WALLABAG_WATCHTOWER_ENABLED:-true}
       - autoheal=true

--- a/services-available/wallos.yml
+++ b/services-available/wallos.yml
@@ -28,6 +28,7 @@ services:
       - traefik.enable=${WALLOS_TRAEFIK_ENABLED:-true}
       - traefik.http.routers.wallos.entrypoints=websecure
       - traefik.http.routers.wallos.rule=Host(`${WALLOS_CONTAINER_NAME:-wallos}.${HOST_DOMAIN}`)
+      - traefik.http.routers.wallos.middlewares=${WALLOS_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       #- traefik.http.services.wallos.loadbalancer.server.scheme=https # enable if the service wants to connect over https
       - traefik.http.services.wallos.loadbalancer.server.port=80
       - com.centurylinklabs.watchtower.enable=${WALLOS_WATCHTOWER_ENABLED:-true}

--- a/services-available/watcharr.yml
+++ b/services-available/watcharr.yml
@@ -27,6 +27,7 @@ services:
       - traefik.enable=true
       - traefik.http.routers.watcharr.entrypoints=websecure
       - traefik.http.routers.watcharr.rule=Host(`${WATCHARR_CONTAINER_NAME:-watcharr}.${HOST_DOMAIN}`)
+      - traefik.http.routers.watcharr.middlewares=${WATCHARR_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.watcharr.loadbalancer.server.port=3080
       - com.centurylinklabs.watchtower.enable=${WATCHARR_WATCHTOWER_ENABLED:-true}
       - autoheal=true    

--- a/services-available/watchyourlan.yml
+++ b/services-available/watchyourlan.yml
@@ -26,6 +26,7 @@ services:
       - traefik.enable=true
       - traefik.http.routers.watchyourlan.entrypoints=websecure
       - traefik.http.routers.watchyourlan.rule=Host(`${WATCHYOURLAN_CONTAINER_NAME:-watchyourlan}.${HOST_DOMAIN}`)
+      - traefik.http.routers.watchyourlan.middlewares=${WATCHYOURLAN_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.watchyourlan.loadbalancer.server.port=8840
       - com.centurylinklabs.watchtower.enable=${WATCHYOURLAN_WATCHTOWER_ENABLED:-true}
       - autoheal=true

--- a/services-available/wbo.yml
+++ b/services-available/wbo.yml
@@ -27,6 +27,7 @@ services:
       - traefik.enable=true
       - traefik.http.routers.wbo.entrypoints=websecure
       - traefik.http.routers.wbo.rule=Host(`${WBO_CONTAINER_NAME:-wbo}.${HOST_DOMAIN}`)
+      - traefik.http.routers.wbo.middlewares=${WBO_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       #- traefik.http.services.wbo.loadbalancer.server.scheme=https # enable if the service wants to connect over https
       - traefik.http.services.wbo.loadbalancer.server.port=80
       - com.centurylinklabs.watchtower.enable=${WBO_WATCHTOWER_ENABLED:-true}

--- a/services-available/webmap.yml
+++ b/services-available/webmap.yml
@@ -26,6 +26,7 @@ services:
       - traefik.enable=true
       - traefik.http.routers.webmap.entrypoints=websecure
       - traefik.http.routers.webmap.rule=Host(`${WEBMAP_CONTAINER_NAME:-webmap}.${HOST_DOMAIN}`)
+      - traefik.http.routers.webmap.middlewares=${WEBMAP_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.webmap.loadbalancer.server.port=8000
       - com.centurylinklabs.watchtower.enable=${WEBMAP_WATCHTOWER_ENABLED:-true}
       - autoheal=true

--- a/services-available/webtop.yml
+++ b/services-available/webtop.yml
@@ -26,6 +26,7 @@ services:
       - traefik.enable=true
       - traefik.http.routers.webtop.entrypoints=websecure
       - traefik.http.routers.webtop.rule=Host(`${WEBTOP_CONTAINER_NAME:-webtop}.${HOST_DOMAIN}`)
+      - traefik.http.routers.webtop.middlewares=${WEBTOP_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.webtop.loadbalancer.server.port=3000
       - com.centurylinklabs.watchtower.enable=${WEBTOP_WATCHTOWER_ENABLED:-true}
       - autoheal=true

--- a/services-available/wetty.yml
+++ b/services-available/wetty.yml
@@ -39,6 +39,7 @@ services:
       - traefik.enable=${WETTY_TRAEFIK_ENABLED:-true}
       - traefik.http.routers.wetty.entrypoints=websecure
       - traefik.http.routers.wetty.rule=Host(`${WETTY_CONTAINER_NAME:-wetty}.${HOST_DOMAIN}`)
+      - traefik.http.routers.wetty.middlewares=${WETTY_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.wetty.loadbalancer.server.port=3000
       - com.centurylinklabs.watchtower.enable=${WETTY_WATCHTOWER_ENABLED:-true}
       - autoheal=${WETTY_AUTOHEAL_ENABLED:-true}

--- a/services-available/wg-easy.yml
+++ b/services-available/wg-easy.yml
@@ -37,6 +37,7 @@ services:
       - traefik.enable=true
       - traefik.http.routers.wg-easy.entrypoints=websecure
       - traefik.http.routers.wg-easy.rule=Host(`${WG_EASY_CONTAINER_NAME:-wg-easy}.${HOST_DOMAIN}`)
+      - traefik.http.routers.wg-easy.middlewares=${WG_EASY_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.wg-easy.loadbalancer.server.port=51821
       - com.centurylinklabs.watchtower.enable=${WG_EASY_WATCHTOWER_ENABLED:-true}
       - autoheal=true

--- a/services-available/whoami.yml
+++ b/services-available/whoami.yml
@@ -25,6 +25,7 @@ services:
       - traefik.enable=true
       - traefik.http.routers.whoami.entrypoints=websecure
       - traefik.http.routers.whoami.rule=Host(`${WHOAMI_CONTAINER_NAME:-whoami}.${HOST_DOMAIN}`)
+      - traefik.http.routers.whoami.middlewares=${WHOAMI_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.whoami.loadbalancer.server.port=80
       #- traefik.http.routers.whoami.middlewares=authentik@docker
       #- traefik.http.routers.whoami.middlewares=authelia@docker

--- a/services-available/wikijs.yml
+++ b/services-available/wikijs.yml
@@ -28,6 +28,7 @@ services:
       - traefik.enable=true
       - traefik.http.routers.wikijs.entrypoints=websecure
       - traefik.http.routers.wikijs.rule=Host(`${WIKIJS_CONTAINER_NAME:-wikijs}.${HOST_DOMAIN}`)
+      - traefik.http.routers.wikijs.middlewares=${WIKIJS_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.wikijs.loadbalancer.server.port=3000
       - com.centurylinklabs.watchtower.enable=${WIKIJS_WATCHTOWER_ENABLED:-true}
       - autoheal=true

--- a/services-available/windows.yml
+++ b/services-available/windows.yml
@@ -32,6 +32,7 @@ services:
       - traefik.enable=${WINDOWS_TRAEFIK_ENABLED:-true}
       - traefik.http.routers.windows.entrypoints=websecure
       - traefik.http.routers.windows.rule=Host(`${WINDOWS_HOST_NAME:-windows}.${HOST_DOMAIN}`)
+      - traefik.http.routers.windows.middlewares=${WINDOWS_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       #- traefik.http.services.windows.loadbalancer.server.scheme=https # enable if the service wants to connect over https
       - traefik.http.services.windows.loadbalancer.server.port=8006
       - com.centurylinklabs.watchtower.enable=${WINDOWS_WATCHTOWER_ENABLED:-true}

--- a/services-available/wireshark.yml
+++ b/services-available/wireshark.yml
@@ -35,6 +35,7 @@ services:
       - traefik.enable=true
       - traefik.http.routers.wireshark.entrypoints=websecure
       - traefik.http.routers.wireshark.rule=Host(`${WIRESHARK_CONTAINER_NAME:-wireshark}.${HOST_DOMAIN}`)
+      - traefik.http.routers.wireshark.middlewares=${WIRESHARK_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.wireshark.loadbalancer.server.port=3000
       - com.centurylinklabs.watchtower.enable=${WIRESHARK_WATCHTOWER_ENABLED:-true}
       - autoheal=true

--- a/services-available/wizarr.yml
+++ b/services-available/wizarr.yml
@@ -34,6 +34,7 @@ services:
       - traefik.enable=${WIZARR_TRAEFIK_ENABLED:-true}
       - traefik.http.routers.wizarr.entrypoints=websecure
       - traefik.http.routers.wizarr.rule=Host(`${WIZARR_HOST_NAME:-wizarr}.${HOST_DOMAIN}`)
+      - traefik.http.routers.wizarr.middlewares=${WIZARR_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       #- traefik.http.services.wizarr.loadbalancer.server.scheme=https # enable if the service wants to connect over https
       - traefik.http.services.wizarr.loadbalancer.server.port=5690
       - com.centurylinklabs.watchtower.enable=${WIZARR_WATCHTOWER_ENABLED:-true}

--- a/services-available/woodpecker.yml
+++ b/services-available/woodpecker.yml
@@ -37,6 +37,7 @@ services:
       - traefik.enable=true
       - traefik.http.routers.woodpecker.entrypoints=websecure
       - traefik.http.routers.woodpecker.rule=Host(`${WOODPECKER_CONTAINER_NAME:-woodpecker}.${HOST_DOMAIN}`)
+      - traefik.http.routers.woodpecker.middlewares=${WOODPECKER_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.woodpecker.loadbalancer.server.port=8000
       - com.centurylinklabs.watchtower.enable=${WOODPECKER_WATCHTOWER_ENABLED:-true}
       - autoheal=true

--- a/services-available/wordpress.yml
+++ b/services-available/wordpress.yml
@@ -33,6 +33,7 @@ services:
       - traefik.enable=true
       - traefik.http.routers.wordpress.entrypoints=websecure
       - traefik.http.routers.wordpress.rule=Host(`${WORDPRESS_HOST_NAME:-wordpress}.${HOST_DOMAIN}`)
+      - traefik.http.routers.wordpress.middlewares=${WORDPRESS_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.wordpress.loadbalancer.server.port=80
       - com.centurylinklabs.watchtower.enable=${WORDPRESS_WATCHTOWER_ENABLED:-true}
       - autoheal=true

--- a/services-available/yacht.yml
+++ b/services-available/yacht.yml
@@ -24,4 +24,5 @@ services:
       - traefik.http.routers.yacht.rule=Host(`${YACHT_CONTAINER_NAME:-yacht}.${HOST_DOMAIN}`)
       - traefik.http.routers.yacht.tls=true
       - traefik.http.routers.yacht.service=yacht
+      - traefik.http.routers.yacht.middlewares=${YACHT_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.yacht.loadbalancer.server.port=8000

--- a/services-available/yamtrack.yml
+++ b/services-available/yamtrack.yml
@@ -33,6 +33,7 @@ services:
       - traefik.enable=${YAMTRACK_TRAEFIK_ENABLED:-true}
       - traefik.http.routers.yamtrack.entrypoints=websecure
       - traefik.http.routers.yamtrack.rule=Host(`${YAMTRACK_HOST_NAME:-yamtrack}.${HOST_DOMAIN}`)
+      - traefik.http.routers.yamtrack.middlewares=${YAMTRACK_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.yamtrack.loadbalancer.server.port=8000
       - com.centurylinklabs.watchtower.enable=${YAMTRACK_WATCHTOWER_ENABLED:-true}
       - autoheal=${YAMTRACK_AUTOHEAL_ENABLED:-true}

--- a/services-available/youtube-dl.yml
+++ b/services-available/youtube-dl.yml
@@ -27,6 +27,7 @@ services:
       - traefik.enable=true
       - traefik.http.routers.youtube-dl.entrypoints=websecure
       - traefik.http.routers.youtube-dl.rule=Host(`${YOUTUBE_DL_CONTAINER_NAME:-youtube-dl}.${HOST_DOMAIN}`)
+      - traefik.http.routers.youtube-dl.middlewares=${YOUTUBE_DL_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.youtube-dl.loadbalancer.server.port=8080
       - com.centurylinklabs.watchtower.enable=${YOUTUBE_DL_WATCHTOWER_ENABLED:-true}
       - autoheal=true

--- a/services-available/youtube-transcript-mcp.yml
+++ b/services-available/youtube-transcript-mcp.yml
@@ -43,6 +43,7 @@ services:
       - traefik.enable=${YOUTUBE_TRANSCRIPT_MCP_TRAEFIK_ENABLE:-true}
       - traefik.http.routers.youtube-transcript-mcp.entrypoints=websecure
       - traefik.http.routers.youtube-transcript-mcp.rule=Host(`${YOUTUBE_TRANSCRIPT_MCP_HOST_NAME:-youtube-transcript}.${HOST_DOMAIN}`)
+      - traefik.http.routers.youtube-transcript-mcp.middlewares=${YOUTUBE_TRANSCRIPT_MCP_MIDDLEWARES:-default-headers@file,noindex-headers@file}
       - traefik.http.services.youtube-transcript-mcp.loadbalancer.server.port=${YOUTUBE_TRANSCRIPT_MCP_PORT:-8080}
       - com.centurylinklabs.watchtower.enable=${YOUTUBE_TRANSCRIPT_MCP_WATCHTOWER_ENABLE:-true}
       - autoheal=${YOUTUBE_TRANSCRIPT_MCP_AUTOHEAL:-true}


### PR DESCRIPTION
## Summary

- Splits `X-Robots-Tag` out of the global `default-headers` middleware into a new `noindex-headers` middleware
- Every service YAML now declares its middleware chain explicitly using an env-var pattern, giving users per-service control over search engine indexing
- **Default behavior is unchanged** — existing users who set no new env vars see zero difference

## How it works

Every websecure router now uses the pattern:

```yaml
traefik.http.routers.<service>.middlewares=${SERVICENAME_MIDDLEWARES:-default-headers@file,noindex-headers@file}
```

The default value includes both `default-headers@file` (security headers) and `noindex-headers@file` (X-Robots-Tag: none), which is identical to the behavior before this change.

## Usage

To allow search engine indexing on a specific service, add to its `.env` file:

```bash
SERVICENAME_MIDDLEWARES=default-headers@file
```

This keeps the security headers but removes the `noindex-headers` middleware, allowing crawlers to index that service.

## Details

- Services with existing custom middlewares (rate limiters, redirects, compression) have their original middleware chains preserved in the default value
- Multi-router services share a single env var across all websecure routers
- HTTP-only redirect routers are unchanged
- The entrypoint-level `default-headers@file` middleware remains as a safety net for security headers
- Also fixes a pre-existing duplicate `healthcheck` key in `jellyfin.yml`

## Test plan

- [ ] Verify `make check-yaml` passes (pre-existing `promtail` error excluded)
- [ ] Verify `make test` passes (325 tests)
- [ ] Deploy with zero env changes — confirm all services behave identically to before
- [ ] Set `SERVICENAME_MIDDLEWARES=default-headers@file` for one service — confirm `X-Robots-Tag` header is absent on that service
- [ ] Confirm all other services still return `X-Robots-Tag: none`