### PR TITLE
fix: restore broken string literals and logger variable in sietch scripts

### DIFF
--- a/sietch/scripts/cloudflare.py
+++ b/sietch/scripts/cloudflare.py
@@ -17,7 +17,7 @@ This script handles the DNS API operations that were done via curl/jq.
 """
 
 from logging_config import get_logger, setup_logging
-nlogger = get_logger(__name__)
+logger = get_logger(__name__)
 
 import argparse
 import json
@@ -143,7 +143,7 @@ class CloudflareAPI:
         # Find the record first
         record = self.find_dns_record(name, record_type)
         if not record:
-            logger.info(DNS record not found: {name} ({record_type})")
+            logger.info(f"DNS record not found: {name} ({record_type})")
             return False
 
         record_id = record["id"]
@@ -204,7 +204,7 @@ Examples:
     try:
         api = CloudflareAPI()
     except ValueError as e:
-        logger.error( {e}"))
+        logger.error(f"{e}")
         return 1
 
     try:
@@ -212,33 +212,33 @@ Examples:
             if args.dns_action == "list":
                 records = api.list_dns_records(record_type=args.type)
                 if not records:
-                    logger.info(No DNS records found")
+                    logger.info("No DNS records found")
                     return 0
 
-                logger.info({'Name':<40} {'Type':<8} {'Content':<50}")
-                logger.info(-" * 100)
+                logger.info(f"{'Name':<40} {'Type':<8} {'Content':<50}")
+                logger.info("-" * 100)
                 for r in records:
-                    logger.info({r['name']:<40} {r['type']:<8} {r['content']:<50}")
+                    logger.info(f"{r['name']:<40} {r['type']:<8} {r['content']:<50}")
                 return 0
 
             if args.dns_action == "delete":
                 if api.delete_dns_record(args.name, args.type):
-                    logger.info(Deleted DNS record: {args.name}")
+                    logger.info(f"Deleted DNS record: {args.name}")
                     return 0
                 return 1
 
         if args.command == "zone":
             if args.zone_action == "info":
                 info = api.get_zone_info()
-                logger.info(Zone: {info.get('name')}")
-                logger.info(  ID: {info.get('id')}")
-                logger.info(  Status: {info.get('status')}")
-                logger.info(  Plan: {info.get('plan', {}).get('name')}")
-                logger.info(  Name servers: {', '.join(info.get('name_servers', []))}")
+                logger.info(f"Zone: {info.get('name')}")
+                logger.info(f"  ID: {info.get('id')}")
+                logger.info(f"  Status: {info.get('status')}")
+                logger.info(f"  Plan: {info.get('plan', {}).get('name')}")
+                logger.info(f"  Name servers: {', '.join(info.get('name_servers', []))}")
                 return 0
 
     except RuntimeError as e:
-        logger.error( {e}"))
+        logger.error(f"{e}")
         return 1
 
     parser.print_help()

--- a/sietch/scripts/env_wizard.py
+++ b/sietch/scripts/env_wizard.py
@@ -12,7 +12,7 @@ Usage:
 """
 
 from logging_config import get_logger, setup_logging
-nlogger = get_logger(__name__)
+logger = get_logger(__name__)
 
 import argparse
 import getpass
@@ -197,8 +197,8 @@ class EnvWizard:
 
     def prompt_text(self, var: EnvVariable, default: str | None = None) -> str:
         """Prompt for a text value with help text."""
-        logger.info(\n{var.name}")
-        logger.info(-" * len(var.name))
+        logger.info(f"\n{var.name}")
+        logger.info("-" * len(var.name))
         logger.info(var.help_text)
 
         if default:
@@ -215,7 +215,7 @@ class EnvWizard:
                     return value
                 if not var.required:
                     return ""
-                logger.info(This field is required. Please enter a value.")
+                logger.info("This field is required. Please enter a value.")
             except EOFError:
                 # Non-interactive, use default if available
                 if default:
@@ -224,8 +224,8 @@ class EnvWizard:
 
     def prompt_sensitive(self, var: EnvVariable) -> str:
         """Prompt for a sensitive value (hidden input)."""
-        logger.info(\n{var.name}")
-        logger.info(-" * len(var.name))
+        logger.info(f"\n{var.name}")
+        logger.info("-" * len(var.name))
         logger.info(var.help_text)
 
         while True:
@@ -235,20 +235,20 @@ class EnvWizard:
                     return value
                 if not var.required:
                     return ""
-                logger.info(This field is required. Please enter a value.")
+                logger.info("This field is required. Please enter a value.")
             except EOFError:
                 return ""
 
     def prompt_choice(self, var: EnvVariable, choices: list[tuple[str, str]]) -> str:
         """Prompt with a numbered menu of choices."""
-        logger.info(\n{var.name}")
-        logger.info(-" * len(var.name))
+        logger.info(f"\n{var.name}")
+        logger.info("-" * len(var.name))
         logger.info(var.help_text)
         logger.info("")
 
         for i, (value, label) in enumerate(choices, 1):
-            logger.info(  {i}. {label}")
-        logger.info(  {len(choices) + 1}. Other (enter manually)")
+            logger.info(f"  {i}. {label}")
+        logger.info(f"  {len(choices) + 1}. Other (enter manually)")
 
         while True:
             try:
@@ -274,7 +274,7 @@ class EnvWizard:
 
                 if not var.required:
                     return ""
-                logger.info(Please select an option or enter a value.")
+                logger.info("Please select an option or enter a value.")
             except EOFError:
                 return ""
 
@@ -288,9 +288,9 @@ class EnvWizard:
 
         if system_tz:
             # System has a non-UTC timezone, offer it as default
-            logger.info(\nTZ")
-            logger.info(-" * 2)
-            logger.info(Detected system timezone: {system_tz}")
+            logger.info("\nTZ")
+            logger.info("-" * 2)
+            logger.info(f"Detected system timezone: {system_tz}")
             logger.info("")
             try:
                 use_system = input(f"Use {system_tz}? [Y/n]: ").strip().lower()
@@ -364,9 +364,9 @@ class EnvWizard:
 
         Returns True if configuration is complete, False otherwise.
         """
-        logger.info(=" * 50)
-        logger.info(OnRamp Environment Setup Wizard")
-        logger.info(=" * 50)
+        logger.info("=" * 50)
+        logger.info("OnRamp Environment Setup Wizard")
+        logger.info("=" * 50)
 
         # Load existing values
         main_env = self.load_env_file(self.main_env_file)
@@ -375,19 +375,19 @@ class EnvWizard:
         # Check what's already configured
         is_complete, missing = self.check_complete()
         if is_complete:
-            logger.info(\nAll required values are already configured.")
+            logger.info("\nAll required values are already configured.")
             return True
 
         if skip_wizard:
-            logger.info(\nSkipping wizard (--skip-wizard flag).")
-            logger.info(Missing required values: {', '.join(missing)}")
-            logger.info(Run 'make edit-env-onramp' to configure manually.")
+            logger.info("\nSkipping wizard (--skip-wizard flag).")
+            logger.info(f"Missing required values: {', '.join(missing)}")
+            logger.info("Run 'make edit-env-onramp' to configure manually.")
             return False
 
         # Offer escape hatch
-        logger.info(\nMissing configuration: {', '.join(missing)}")
+        logger.info(f"\nMissing configuration: {', '.join(missing)}")
         if not self.prompt_yes_no("Would you like to configure these now?", default=True):
-            logger.info(\nSkipping wizard. Run 'make edit-env-onramp' to configure manually.")
+            logger.info("\nSkipping wizard. Run 'make edit-env-onramp' to configure manually.")
             return False
 
         # Collect new values
@@ -400,11 +400,11 @@ class EnvWizard:
 
         if not self.get_existing_value("PUID", main_env):
             main_updates["PUID"] = puid
-            logger.info(\nAuto-detected PUID: {puid}")
+            logger.info(f"\nAuto-detected PUID: {puid}")
 
         if not self.get_existing_value("PGID", main_env):
             main_updates["PGID"] = pgid
-            logger.info(Auto-detected PGID: {pgid}")
+            logger.info(f"Auto-detected PGID: {pgid}")
 
         # Prompt for main env vars
         for var in MAIN_ENV_VARS:
@@ -424,15 +424,15 @@ class EnvWizard:
         # Write updates
         if main_updates:
             self.update_env_file(self.main_env_file, main_updates)
-            logger.info(\nUpdated: {self.main_env_file}")
+            logger.info(f"\nUpdated: {self.main_env_file}")
 
         if nfs_updates:
             self.update_env_file(self.nfs_env_file, nfs_updates)
-            logger.info(Updated: {self.nfs_env_file}")
+            logger.info(f"Updated: {self.nfs_env_file}")
 
-        logger.info(\n" + "=" * 50)
-        logger.info(Configuration complete!")
-        logger.info(=" * 50)
+        logger.info("\n" + "=" * 50)
+        logger.info("Configuration complete!")
+        logger.info("=" * 50)
 
         return True
 
@@ -469,10 +469,10 @@ def main():
     if args.check:
         is_complete, missing = wizard.check_complete()
         if is_complete:
-            logger.info(Configuration is complete.")
+            logger.info("Configuration is complete.")
             return 0
         else:
-            logger.info(Missing required values: {', '.join(missing)}")
+            logger.info(f"Missing required values: {', '.join(missing)}")
             return 1
 
     success = wizard.run_wizard(skip_wizard=args.skip_wizard)

--- a/sietch/scripts/extract_env.py
+++ b/sietch/scripts/extract_env.py
@@ -17,7 +17,7 @@ Usage:
 """
 
 from logging_config import get_logger, setup_logging
-nlogger = get_logger(__name__)
+logger = get_logger(__name__)
 
 import argparse
 import re
@@ -231,7 +231,7 @@ def main() -> int:
         logger.info(result)
         return 0
     else:
-        logger.error( {result}"))
+        logger.error(f"{result}")
         return 1
 
 

--- a/sietch/scripts/healthcheck_audit.py
+++ b/sietch/scripts/healthcheck_audit.py
@@ -12,7 +12,7 @@ Usage:
 """
 
 from logging_config import get_logger, setup_logging
-nlogger = get_logger(__name__)
+logger = get_logger(__name__)
 
 import argparse
 import json
@@ -111,33 +111,33 @@ def audit_services(
 
 def print_text_report(results: list[dict], stats: dict) -> None:
     """Print human-readable audit report."""
-    logger.info(=" * 60)
-    logger.info(HEALTH CHECK AUDIT REPORT")
-    logger.info(=" * 60)
+    logger.info("=" * 60)
+    logger.info("HEALTH CHECK AUDIT REPORT")
+    logger.info("=" * 60)
     logger.info("")
 
     # Statistics
-    logger.info(STATISTICS")
-    logger.info(-" * 40)
-    logger.info(Total services scanned: {stats['total']}")
-    logger.info(With health checks: {stats['with_healthcheck']}")
-    logger.info(With autoheal label: {stats['with_autoheal']}")
-    logger.info(Autoheal WITHOUT healthcheck: {stats['autoheal_no_healthcheck']}")
+    logger.info("STATISTICS")
+    logger.info("-" * 40)
+    logger.info(f"Total services scanned: {stats['total']}")
+    logger.info(f"With health checks: {stats['with_healthcheck']}")
+    logger.info(f"With autoheal label: {stats['with_autoheal']}")
+    logger.info(f"Autoheal WITHOUT healthcheck: {stats['autoheal_no_healthcheck']}")
     logger.info("")
 
     if stats["total"] > 0:
         coverage = (stats["with_healthcheck"] / stats["total"]) * 100
-        logger.info(Health check coverage: {coverage:.1f}%")
+        logger.info(f"Health check coverage: {coverage:.1f}%")
         logger.info("")
 
     # Critical: autoheal without healthcheck
     critical = [r for r in results if r["has_autoheal"] and not r["has_healthcheck"]]
     if critical:
-        logger.info(CRITICAL: Services with autoheal but NO healthcheck")
-        logger.info(-" * 40)
+        logger.info("CRITICAL: Services with autoheal but NO healthcheck")
+        logger.info("-" * 40)
         for r in critical:
             status = "[enabled]" if r["enabled"] else "[available]"
-            logger.info(  {status} {r['service']}")
+            logger.info(f"  {status} {r['service']}")
         logger.info("")
 
     # Services without health checks (enabled only)
@@ -145,21 +145,21 @@ def print_text_report(results: list[dict], stats: dict) -> None:
         r for r in results if not r["has_healthcheck"] and r["enabled"]
     ]
     if no_healthcheck:
-        logger.info(ENABLED services without health checks")
-        logger.info(-" * 40)
+        logger.info("ENABLED services without health checks")
+        logger.info("-" * 40)
         for r in no_healthcheck:
             autoheal = " (autoheal)" if r["has_autoheal"] else ""
-            logger.info(  {r['service']}{autoheal}")
+            logger.info(f"  {r['service']}{autoheal}")
         logger.info("")
 
     # Services with health checks
     with_healthcheck = [r for r in results if r["has_healthcheck"]]
     if with_healthcheck:
-        logger.info(Services WITH health checks")
-        logger.info(-" * 40)
+        logger.info("Services WITH health checks")
+        logger.info("-" * 40)
         for r in with_healthcheck:
             status = "[enabled]" if r["enabled"] else "[available]"
-            logger.info(  {status} {r['service']}")
+            logger.info(f"  {status} {r['service']}")
         logger.info("")
 
 

--- a/sietch/scripts/migrate-env.py
+++ b/sietch/scripts/migrate-env.py
@@ -348,14 +348,14 @@ class EnvMigrator:
 
             logger.info("Found {len(migrations)} environment files to migrate:")
             for source, dest, desc in migrations:
-                logger.info(    {source.name} -> {dest.name} ({desc})")
+                logger.info(f"    {source.name} -> {dest.name} ({desc})")
         else:
             logger.info("No environment files found in environments-enabled/")
             if has_templates:
                 logger.info("Will clean up templates directory only")
 
         if dry_run:
-            logger.info(\nDry run - no changes made")
+            logger.info("\nDry run - no changes made")
             return True
 
         # Create backup directory
@@ -376,7 +376,7 @@ class EnvMigrator:
                     f.write("\n")
                     f.write(content)
 
-                logger.info("Created file", extra={"name": {dest.name}")
+                logger.info("Created file", extra={"name": f"{dest.name}"})
 
         # Backup and remove environments-enabled/ if it exists
         if has_env_dir:
@@ -384,10 +384,10 @@ class EnvMigrator:
             if backup_path.exists():
                 shutil.rmtree(backup_path)
             shutil.copytree(self.environments_enabled, backup_path)
-            logger.info("Backed up", extra={"message": environments-enabled/ -> backups/environments-enabled.legacy/")
+            logger.info("Backed up", extra={"message": "environments-enabled/ -> backups/environments-enabled.legacy/"})
 
             shutil.rmtree(self.environments_enabled)
-            logger.info("Removed", extra={"message": environments-enabled/")
+            logger.info("Removed", extra={"message": "environments-enabled/"})
 
         # Clean up environments-available/ templates if they exist
         if has_templates:
@@ -395,12 +395,12 @@ class EnvMigrator:
             if templates_backup.exists():
                 shutil.rmtree(templates_backup)
             shutil.copytree(self.environments_available, templates_backup)
-            logger.info("Backed up", extra={"message": environments-available/ -> backups/environments-available.legacy/")
+            logger.info("Backed up", extra={"message": "environments-available/ -> backups/environments-available.legacy/"})
 
             shutil.rmtree(self.environments_available)
-            logger.info("Removed", extra={"message": environments-available/")
+            logger.info("Removed", extra={"message": "environments-available/"})
 
-        logger.info(\nMigration complete!")
+        logger.info("\nMigration complete!")
         return True
 
     def _is_nfs_var(self, var_name: str) -> bool:
@@ -449,7 +449,7 @@ class EnvMigrator:
         if "CF_API_EMAIL" not in global_vars and "DNS_CHALLENGE_API_EMAIL" in global_vars:
             value, comments = global_vars["DNS_CHALLENGE_API_EMAIL"]
             global_vars["CF_API_EMAIL"] = (value, ["# Copied from DNS_CHALLENGE_API_EMAIL"])
-            logger.info(  Aliased: CF_API_EMAIL <- DNS_CHALLENGE_API_EMAIL")
+            logger.info("  Aliased: CF_API_EMAIL <- DNS_CHALLENGE_API_EMAIL")
 
         logger.info("Global vars: {len(global_vars)}")
         logger.info("NFS vars: {len(nfs_vars)}")
@@ -458,10 +458,10 @@ class EnvMigrator:
         logger.info("Custom/unmapped vars: {len(custom_vars)}")
 
         if dry_run:
-            logger.info(\nDry run - no changes made")
-            logger.info(\nGlobal vars would be written to services-enabled/.env:")
+            logger.info("\nDry run - no changes made")
+            logger.info("\nGlobal vars would be written to services-enabled/.env:")
             for var in sorted(global_vars.keys()):
-                logger.info(  {var}")
+                logger.info(f"  {var}")
             if nfs_vars:
                 logger.info("NFS vars would be written to services-enabled/.env.nfs:")
                 for var in sorted(nfs_vars.keys()):
@@ -487,54 +487,54 @@ class EnvMigrator:
         if global_vars:
             header = f"# OnRamp Global Configuration\n# Migrated from legacy .env on {timestamp}"
             self.write_env_file(self.services_enabled / ".env", global_vars, header)
-            logger.info("Created file", extra={"name": services-enabled/.env ({len(global_vars)} vars)")
+            logger.info("Created file", extra={"name": f"services-enabled/.env ({len(global_vars)} vars)"})
 
         # Write NFS config
         if nfs_vars:
             header = f"# NFS/SAMBA Configuration\n# Migrated from legacy .env on {timestamp}"
             self.write_env_file(self.services_enabled / ".env.nfs", nfs_vars, header)
-            logger.info("Created file", extra={"name": services-enabled/.env.nfs ({len(nfs_vars)} vars)")
+            logger.info("Created file", extra={"name": f"services-enabled/.env.nfs ({len(nfs_vars)} vars)"})
 
         # Write external services config
         if external_vars:
             header = f"# External Service Proxying\n# Migrated from legacy .env on {timestamp}"
             self.write_env_file(self.services_enabled / ".env.external", external_vars, header)
-            logger.info("Created file", extra={"name": services-enabled/.env.external ({len(external_vars)} vars)")
+            logger.info("Created file", extra={"name": f"services-enabled/.env.external ({len(external_vars)} vars)"})
 
         # Write service-specific configs
         for service, svars in service_vars.items():
             header = f"# {service.upper()} Configuration\n# Migrated from legacy .env on {timestamp}"
             self.write_env_file(self.services_enabled / f"{service}.env", svars, header)
-            logger.info("Created file", extra={"name": services-enabled/{service}.env ({len(svars)} vars)")
+            logger.info("Created file", extra={"name": f"services-enabled/{service}.env ({len(svars)} vars)"})
 
         # Write unmapped variables to custom.env
         if custom_vars:
             header = f"# Custom/Unmapped Variables\n# Migrated from legacy .env on {timestamp}"
             self.write_env_file(self.services_enabled / "custom.env", custom_vars, header)
-            logger.info("Created file", extra={"name": services-enabled/custom.env ({len(custom_vars)} vars)")
+            logger.info("Created file", extra={"name": f"services-enabled/custom.env ({len(custom_vars)} vars)"})
 
         # Backup and remove legacy .env
         self.backups_dir.mkdir(parents=True, exist_ok=True)
         backup_path = self.backups_dir / ".env.legacy"
         shutil.copy2(self.legacy_env, backup_path)
-        logger.info("Backed up", extra={"message": .env -> {backup_path}")
+        logger.info("Backed up", extra={"message": f".env -> {backup_path}"})
 
         self.legacy_env.unlink()
-        logger.info("Removed", extra={"message": .env")
+        logger.info("Removed", extra={"message": ".env"})
 
-        logger.info(\nMigration complete!")
+        logger.info("\nMigration complete!")
         return True
 
     def migrate(self, dry_run: bool = False) -> bool:
         """Route to appropriate migration based on detected source."""
         if (self.services_enabled / ".env").exists():
-            logger.info(services-enabled/.env already exists. Migration already complete.")
+            logger.info("services-enabled/.env already exists. Migration already complete.")
             return True
         if self.should_migrate_feature_branch():
             return self.migrate_feature_branch(dry_run)
         if self.should_migrate_legacy():
             return self.migrate_legacy(dry_run)
-        logger.info(No migration source found (.env or environments-enabled/).")
+        logger.info("No migration source found (.env or environments-enabled/).")
         return True
 
 

--- a/sietch/scripts/migrate_service_env.py
+++ b/sietch/scripts/migrate_service_env.py
@@ -9,7 +9,7 @@ Migrations are versioned and tracked to ensure they only run once.
 """
 
 from logging_config import get_logger, setup_logging
-nlogger = get_logger(__name__)
+logger = get_logger(__name__)
 
 import argparse
 import json
@@ -282,7 +282,7 @@ class ServiceEnvMigrator:
         Returns True if successful, False if errors occurred.
         """
         if service not in SERVICE_MIGRATIONS:
-            logger.info(No migrations defined for service: {service}")
+            logger.info(f"No migrations defined for service: {service}")
             return True
 
         migrations = SERVICE_MIGRATIONS[service]
@@ -290,31 +290,31 @@ class ServiceEnvMigrator:
         pending = [m for m in migrations if m["version"] > current_version]
 
         if not pending:
-            logger.info({service}: Already at latest version (v{current_version})")
+            logger.info(f"{service}: Already at latest version (v{current_version})")
             return True
 
         env_file = self.get_env_file(service)
 
-        logger.info(\n{'='*60}")
-        logger.info(Service: {service}")
-        logger.info(Current version: {current_version}")
-        logger.info(Pending migrations: {len(pending)}")
-        logger.info({'='*60}")
+        logger.info(f"\n{'='*60}")
+        logger.info(f"Service: {service}")
+        logger.info(f"Current version: {current_version}")
+        logger.info(f"Pending migrations: {len(pending)}")
+        logger.info(f"{'='*60}")
 
         for migration in pending:
             version = migration["version"]
             desc = migration["description"]
 
-            logger.info(\n[v{version}] {desc}")
+            logger.info(f"\n[v{version}] {desc}")
 
             if migration.get("notes"):
-                logger.info(\nNotes:")
+                logger.info("\nNotes:")
                 for note in migration["notes"]:
-                    logger.info(  {note}")
+                    logger.info(f"  {note}")
 
             if not env_file.exists():
-                logger.info(\n  No env file found at {env_file}")
-                logger.info(  Creating placeholder for manual configuration...")
+                logger.info(f"\n  No env file found at {env_file}")
+                logger.info("  Creating placeholder for manual configuration...")
 
                 if not dry_run:
                     env_file.parent.mkdir(parents=True, exist_ok=True)
@@ -342,7 +342,7 @@ class ServiceEnvMigrator:
                 for line_type, var_name, content in lines:
                     if line_type == "var" and var_name in transforms:
                         new_var = transforms[var_name]
-                        logger.info(  Transform: {var_name} -> {new_var}")
+                        logger.info(f"  Transform: {var_name} -> {new_var}")
                         # Comment out old var
                         new_lines.append(("comment", None, f"# MIGRATED: {var_name}={content}"))
                         # Add new var
@@ -353,14 +353,14 @@ class ServiceEnvMigrator:
                 lines = new_lines
 
             if dry_run:
-                logger.info(\n  [DRY RUN] Would apply migration")
+                logger.info("\n  [DRY RUN] Would apply migration")
                 if modified:
-                    logger.info(  Changes would be written to env file")
+                    logger.info("  Changes would be written to env file")
             else:
                 # Backup before modifying
                 backup = self.backup_env_file(service)
                 if backup:
-                    logger.info(\n  Backup: {backup.name}")
+                    logger.info(f"\n  Backup: {backup.name}")
 
                 # Add migration header if not already present
                 header_lines = [
@@ -380,7 +380,7 @@ class ServiceEnvMigrator:
 
                 self.write_env_file(env_file, lines)
                 self.set_applied_version(service, version)
-                logger.info(\n  Applied migration v{version}")
+                logger.info(f"\n  Applied migration v{version}")
 
         return True
 
@@ -397,20 +397,20 @@ class ServiceEnvMigrator:
         state = self.load_state()
         applied = state.get("applied", {})
 
-        logger.info(\nService Environment Migrations")
-        logger.info(=" * 60)
+        logger.info("\nService Environment Migrations")
+        logger.info("=" * 60)
 
         for service, migrations in sorted(SERVICE_MIGRATIONS.items()):
             current = applied.get(service, 0)
             latest = max(m["version"] for m in migrations)
             status = "up-to-date" if current >= latest else f"pending ({latest - current} migration(s))"
 
-            logger.info(\n{service}:")
-            logger.info(  Current: v{current}, Latest: v{latest} [{status}]")
+            logger.info(f"\n{service}:")
+            logger.info(f"  Current: v{current}, Latest: v{latest} [{status}]")
 
             for m in migrations:
                 marker = "[x]" if m["version"] <= current else "[ ]"
-                logger.info(  {marker} v{m['version']}: {m['description']}")
+                logger.info(f"  {marker} v{m['version']}: {m['description']}")
 
     def check_service(self, service: str) -> dict:
         """Check migration status for a service."""
@@ -490,12 +490,12 @@ Examples:
     elif args.command == "check":
         status = migrator.check_service(args.service)
         if not status["defined"]:
-            logger.info(No migrations defined for: {args.service}")
+            logger.info(f"No migrations defined for: {args.service}")
             return 0
-        logger.info(Service: {status['service']}")
-        logger.info(Current version: {status['current_version']}")
-        logger.info(Latest version: {status['latest_version']}")
-        logger.info(Status: {'up-to-date' if status['up_to_date'] else f'{status[\"pending_count\"]} pending'}")
+        logger.info(f"Service: {status['service']}")
+        logger.info(f"Current version: {status['current_version']}")
+        logger.info(f"Latest version: {status['latest_version']}")
+        logger.info(f"Status: {'up-to-date' if status['up_to_date'] else f'{status["pending_count"]} pending'}")
         return 0
 
     else:

--- a/sietch/scripts/services_linter.py
+++ b/sietch/scripts/services_linter.py
@@ -6,7 +6,7 @@ Validates service YAML files against OnRamp standards and best practices.
 """
 
 from logging_config import get_logger, setup_logging
-nlogger = get_logger(__name__)
+logger = get_logger(__name__)
 
 import re
 import sys
@@ -386,18 +386,18 @@ Examples:
     if args.all or args.enabled:
         results = linter.lint_all(enabled_only=args.enabled)
 
-        logger.info(Passed: {len(results['passed'])}")
-        logger.info(Failed: {len(results['failed'])}")
+        logger.info(f"Passed: {len(results['passed'])}")
+        logger.info(f"Failed: {len(results['failed'])}")
 
         if results["all_errors"]:
-            logger.info(\nErrors:")
+            logger.info("\nErrors:")
             for err in results["all_errors"]:
-                logger.info(  - {err}")
+                logger.info(f"  - {err}")
 
         if results["all_warnings"]:
-            logger.info(\nWarnings:")
+            logger.info("\nWarnings:")
             for warn in results["all_warnings"]:
-                logger.info(  - {warn}")
+                logger.info(f"  - {warn}")
 
         return 1 if results["failed"] else 0
 
@@ -406,18 +406,18 @@ Examples:
 
     is_valid, errors, warnings = linter.lint(args.service, strict=args.strict)
 
-    logger.info(Linting: {args.service}")
-    logger.info(Valid: {is_valid}")
+    logger.info(f"Linting: {args.service}")
+    logger.info(f"Valid: {is_valid}")
 
     if errors:
-        logger.info(\nErrors:")
+        logger.info("\nErrors:")
         for err in errors:
-            logger.info(  - {err}")
+            logger.info(f"  - {err}")
 
     if warnings:
-        logger.info(\nWarnings:")
+        logger.info("\nWarnings:")
         for warn in warnings:
-            logger.info(  - {warn}")
+            logger.info(f"  - {warn}")
 
     return 0 if is_valid else 1
 

--- a/sietch/scripts/traefik_hosts.py
+++ b/sietch/scripts/traefik_hosts.py
@@ -17,7 +17,7 @@ Features:
 """
 
 from logging_config import get_logger, setup_logging
-nlogger = get_logger(__name__)
+logger = get_logger(__name__)
 
 import argparse
 import os
@@ -145,7 +145,7 @@ class TraefikHostsExtractor:
         try:
             content = yaml_path.read_text(encoding="utf-8")
         except OSError as e:
-            logger.warning( Could not read {yaml_path}: {e}"))
+            logger.warning(f"Could not read {yaml_path}: {e}")
             return hosts
 
         for match in HOST_RULE_PATTERN.finditer(content):
@@ -277,18 +277,18 @@ class TraefikHostsExtractor:
         host_domain = self.env_vars.get("HOST_DOMAIN", "")
 
         if not hostip:
-            logger.error( HOSTIP not set in environment"))
+            logger.error("HOSTIP not set in environment")
             return 1
 
         if not host_domain:
-            logger.error( HOST_DOMAIN not set in environment"))
+            logger.error("HOST_DOMAIN not set in environment")
             return 1
 
         # Get external files to process
         external_files = self.get_external_files()
 
         if not external_files:
-            logger.info(No external configs found in external-enabled/")
+            logger.info("No external configs found in external-enabled/")
             return 0
 
         # Read existing hosts file
@@ -317,11 +317,11 @@ class TraefikHostsExtractor:
 
         # Print summary
         if added:
-            logger.info(Added: {', '.join(added)}")
+            logger.info(f"Added: {', '.join(added)}")
         if updated:
-            logger.info(Updated: {', '.join(updated)}")
+            logger.info(f"Updated: {', '.join(updated)}")
 
-        logger.info(Wrote {total} host entries to {self.hosts_file}")
+        logger.info(f"Wrote {total} host entries to {self.hosts_file}")
 
         return 0
 


### PR DESCRIPTION
## Problem

Running `make prune-update` (or any command that invokes the Sietch container) would fail with a Python `SyntaxError` in `env_wizard.py`:

```
File "/scripts/env_wizard.py", line 200
    logger.info(\n{var.name}")
                 ^
SyntaxError: unexpected character after line continuation character
```

The corruption was wider than one file — **8 scripts** across `sietch/scripts/` had the same two bugs:

1. **Opening quote characters stripped** from every `logger.info/warning/error()` string literal call, leaving bare text or broken f-string expressions that Python could not parse.
2. **Module-level logger variable misnamed** `nlogger` instead of `logger` in 6 files, causing `NameError` at runtime even after fixing the syntax.

## Files Fixed

- `sietch/scripts/env_wizard.py`
- `sietch/scripts/traefik_hosts.py`
- `sietch/scripts/migrate-env.py`
- `sietch/scripts/services_linter.py`
- `sietch/scripts/extract_env.py`
- `sietch/scripts/cloudflare.py`
- `sietch/scripts/migrate_service_env.py`
- `sietch/scripts/healthcheck_audit.py`

## What Was Fixed (140 changes)

- Missing `"` / `f"` prefixes on ~120 `logger.*()` string calls
- `nlogger = get_logger(...)` → `logger = get_logger(...)` in 6 files
- String multiplication patterns (`"=" * N`, `"-" * N`) with stripped opening quote
- Extra unmatched closing `)` parens on error calls that had been multi-line
- Broken `extra={"name": ...}` structured logging dict values in `migrate-env.py`
- Literal `\"` backslash-escapes inside nested f-string expressions in `migrate_service_env.py`

## Testing

All 8 affected files pass `ast.parse()` syntax check. `make test` confirms no new failures were introduced (pre-existing test failures in backup/database/operations are unrelated — those tests check `captured.out` but the code uses `logger`).